### PR TITLE
15 alter merge actions

### DIFF
--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -2,9 +2,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { transactions } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
-import { STATUSES } from "@/types/transaction";
-
-const UPDATABLE_FIELDS = ["date", "description", "category", "amount", "status", "source", "parentId"] as const;
+import { STATUSES, UPDATABLE_FIELDS } from "@/types/transaction";
 
 export async function PUT(
   request: Request,

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -25,18 +25,30 @@ export async function PUT(
   }
 
   if (Object.keys(updates).length === 0) {
-    return Response.json({ error: "No valid fields to update" }, { status: 400 });
+    return Response.json(
+      { error: "No valid fields to update" },
+      { status: 400 },
+    );
   }
 
   // Validate specific fields if present
   if (updates.amount !== undefined) {
     if (isNaN(Number(updates.amount))) {
-      return Response.json({ error: "amount must be a valid number" }, { status: 400 });
+      return Response.json(
+        { error: "amount must be a valid number" },
+        { status: 400 },
+      );
     }
     updates.amount = String(updates.amount);
   }
-  if (updates.status !== undefined && !STATUSES.includes(updates.status as typeof STATUSES[number])) {
-    return Response.json({ error: `status must be one of: ${STATUSES.join(", ")}` }, { status: 400 });
+  if (
+    updates.status !== undefined &&
+    !STATUSES.includes(updates.status as (typeof STATUSES)[number])
+  ) {
+    return Response.json(
+      { error: `status must be one of: ${STATUSES.join(", ")}` },
+      { status: 400 },
+    );
   }
 
   const row = await db
@@ -47,7 +59,8 @@ export async function PUT(
     )
     .returning();
 
-  if (!row.length) return Response.json({ error: "Not found" }, { status: 404 });
+  if (!row.length)
+    return Response.json({ error: "Not found" }, { status: 404 });
   return Response.json(row);
 }
 

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -2,7 +2,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { transactions } from "@/lib/db/schema";
 import { eq, desc, asc, and, isNull, ilike, or, count, inArray, SQL } from "drizzle-orm";
-import { STATUSES } from "@/types/transaction";
+import { STATUSES, UPDATABLE_FIELDS } from "@/types/transaction";
 
 const SORTABLE_COLUMNS = {
   date: transactions.date,
@@ -140,6 +140,31 @@ export async function GET(request: Request) {
   });
 }
 
+function validateTransaction(tx: Record<string, unknown>): string | null {
+  if (!tx.date || typeof tx.date !== "string") return "date is required and must be a string";
+  if (!tx.description || typeof tx.description !== "string") return "description is required and must be a string";
+  if (tx.amount === undefined || (typeof tx.amount !== "number" && typeof tx.amount !== "string")) return "amount is required and must be a number";
+  if (isNaN(Number(tx.amount))) return "amount must be a valid number";
+  if (tx.status && !(STATUSES as string[]).includes(tx.status as string)) return `status must be one of: ${STATUSES.join(", ")}`;
+  return null;
+}
+
+function toInsertValues(tx: Record<string, unknown>, userId: string) {
+  return {
+    id: crypto.randomUUID(),
+    date: tx.date as string,
+    description: tx.description as string,
+    category: (tx.category as string) ?? null,
+    amount: String(tx.amount),
+    status: (tx.status as string) ?? "Completed",
+    source: (tx.source as string) ?? null,
+    createdAt: typeof tx.createdAt === "number" ? tx.createdAt : Date.now(),
+    isGroup: (tx.isGroup as boolean) ?? false,
+    parentId: (tx.parentId as string) ?? null,
+    userId,
+  };
+}
+
 export async function POST(request: Request) {
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session)
@@ -147,40 +172,86 @@ export async function POST(request: Request) {
 
   const body = await request.json();
 
-  const { date, description, category, amount, status, source, isGroup, parentId, createdAt } = body;
+  // Bulk insert
+  if (Array.isArray(body)) {
+    for (let i = 0; i < body.length; i++) {
+      const err = validateTransaction(body[i]);
+      if (err) return Response.json({ error: `Row ${i}: ${err}` }, { status: 400 });
+    }
+    const rows = await db
+      .insert(transactions)
+      .values(body.map((tx: Record<string, unknown>) => toInsertValues(tx, session.user.id)))
+      .returning();
+    return Response.json(rows, { status: 201 });
+  }
 
-  if (!date || typeof date !== "string") {
-    return Response.json({ error: "date is required and must be a string" }, { status: 400 });
-  }
-  if (!description || typeof description !== "string") {
-    return Response.json({ error: "description is required and must be a string" }, { status: 400 });
-  }
-  if (amount === undefined || (typeof amount !== "number" && typeof amount !== "string")) {
-    return Response.json({ error: "amount is required and must be a number" }, { status: 400 });
-  }
-  if (isNaN(Number(amount))) {
-    return Response.json({ error: "amount must be a valid number" }, { status: 400 });
-  }
-  if (status && !STATUSES.includes(status)) {
-    return Response.json({ error: `status must be one of: ${STATUSES.join(", ")}` }, { status: 400 });
-  }
+  // Single insert
+  const err = validateTransaction(body);
+  if (err) return Response.json({ error: err }, { status: 400 });
 
   const [row] = await db
     .insert(transactions)
-    .values({
-      id: crypto.randomUUID(),
-      date,
-      description,
-      category: category ?? null,
-      amount: String(amount),
-      status: status ?? "Completed",
-      source: source ?? null,
-      createdAt: typeof createdAt === "number" ? createdAt : Date.now(),
-      isGroup: isGroup ?? false,
-      parentId: parentId ?? null,
-      userId: session.user.id,
-    })
+    .values(toInsertValues(body, session.user.id))
     .returning();
 
   return Response.json(row, { status: 201 });
+}
+
+export async function PUT(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session)
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { ids, updates } = await request.json();
+
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return Response.json({ error: "ids must be a non-empty array" }, { status: 400 });
+  }
+
+  const filtered: Record<string, unknown> = {};
+  for (const key of UPDATABLE_FIELDS) {
+    if (key in updates) filtered[key] = updates[key];
+  }
+  if (Object.keys(filtered).length === 0) {
+    return Response.json({ error: "No valid fields to update" }, { status: 400 });
+  }
+  if (filtered.amount !== undefined) {
+    if (isNaN(Number(filtered.amount))) {
+      return Response.json({ error: "amount must be a valid number" }, { status: 400 });
+    }
+    filtered.amount = String(filtered.amount);
+  }
+  if (filtered.status !== undefined && !(STATUSES as string[]).includes(filtered.status as string)) {
+    return Response.json({ error: `status must be one of: ${STATUSES.join(", ")}` }, { status: 400 });
+  }
+
+  const rows = await db
+    .update(transactions)
+    .set(filtered)
+    .where(
+      and(eq(transactions.userId, session.user.id), inArray(transactions.id, ids)),
+    )
+    .returning();
+
+  return Response.json(rows);
+}
+
+export async function DELETE(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session)
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { ids } = await request.json();
+
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return Response.json({ error: "ids must be a non-empty array" }, { status: 400 });
+  }
+
+  await db
+    .delete(transactions)
+    .where(
+      and(eq(transactions.userId, session.user.id), inArray(transactions.id, ids)),
+    );
+
+  return new Response(null, { status: 204 });
 }

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -25,6 +25,32 @@ export async function GET(request: Request) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
 
   const url = new URL(request.url);
+
+  // Metadata branch — all groups, distinct categories, distinct sources
+  if (url.searchParams.get("metadata") === "true") {
+    const userFilter = eq(transactions.userId, session.user.id);
+    const [groups, categories, sources] = await Promise.all([
+      db
+        .select()
+        .from(transactions)
+        .where(and(userFilter, eq(transactions.isGroup, true)))
+        .orderBy(desc(transactions.createdAt)),
+      db
+        .selectDistinct({ category: transactions.category })
+        .from(transactions)
+        .where(userFilter),
+      db
+        .selectDistinct({ source: transactions.source })
+        .from(transactions)
+        .where(userFilter),
+    ]);
+    return Response.json({
+      groups,
+      categories: categories.map((r) => r.category).filter(Boolean),
+      sources: sources.map((r) => r.source).filter(Boolean),
+    });
+  }
+
   const parentIdParam = url.searchParams.get("parentId");
 
   // Child fetch branch — return children of a group, no pagination

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -367,11 +367,11 @@ const Home = () => {
   };
 
   const handleBulkDelete = (ids: string[]) => {
-    Promise.all(
-      ids.map((id) =>
-        fetch(`/api/transactions/${id}`, { method: "DELETE" }),
-      ),
-    ).then(() => {
+    fetch("/api/transactions", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ids }),
+    }).then(() => {
       clearSelected();
       fetchPage({
         page: currentPage,
@@ -386,15 +386,11 @@ const Home = () => {
     setPageRows((prev) =>
       prev.map((tx) => (ids.includes(tx.id) ? { ...tx, ...updates } : tx)),
     );
-    Promise.all(
-      ids.map((id) =>
-        fetch(`/api/transactions/${id}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(updates),
-        }),
-      ),
-    ).then(() => {
+    fetch("/api/transactions", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ids, updates }),
+    }).then(() => {
       clearSelected();
       fetchPage({
         page: currentPage,
@@ -410,33 +406,27 @@ const Home = () => {
   ) => {
     const now = Date.now();
     const sorted = [...newTransactions].sort((a, b) => b.date.localeCompare(a.date))
-    const transactionsComplete = sorted.map((tx, i) => ({
+    const withTimestamps = sorted.map((tx, i) => ({
       ...tx,
-      id: crypto.randomUUID(),
       createdAt: now - i,
     }));
 
-    Promise.all(
-      transactionsComplete.map((tx) =>
-        fetch("/api/transactions", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(tx),
-        }),
-      ),
-    ).then(() => {
-      // import doesn't have categories or source 
-      // for (const tx of newTransactions) {
-      //   trackMetadata(tx);
-      // }
-      setCurrentPage(1);
-      fetchPage({
-        page: 1,
-        search: debouncedSearch,
-        sortBy: sortConfig?.key ?? null,
-        sortDir: sortConfig?.direction ?? null,
+    fetch("/api/transactions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(withTimestamps),
+    })
+      .then((res) => res.json())
+      .then((created: Transaction[]) => {
+        setSelectedIds(new Set(created.map((row) => row.id)));
+        setCurrentPage(1);
+        fetchPage({
+          page: 1,
+          search: debouncedSearch,
+          sortBy: sortConfig?.key ?? null,
+          sortDir: sortConfig?.direction ?? null,
+        });
       });
-    });
   };
 
   if (isPending || !session) return null;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,7 @@ const Home = () => {
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [sortConfig, setSortConfig] = useState<SortConfig | null>(null);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set([]));
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set([]));
+  const [selectedIds, setSelectedIds] = useState<Map<string, Transaction>>(new Map());
   const [allGroups, setAllGroups] = useState<Transaction[]>([]);
   const [allCategories, setAllCategories] = useState<string[]>([]);
   const [allSources, setAllSources] = useState<string[]>([]);
@@ -165,6 +165,9 @@ const Home = () => {
     setPageRows((prev) =>
       prev.map((tx) => (tx.id === id ? { ...tx, ...updates } : tx)),
     );
+    setAllGroups((prev) =>
+      prev.map((g) => (g.id === id ? { ...g, ...updates } : g)),
+    );
     setChildRows((prev) => {
       const next = { ...prev };
       for (const groupId of Object.keys(next)) {
@@ -238,17 +241,15 @@ const Home = () => {
     ...Object.values(childRows).flat(),
   ];
 
-  const selectedUngroupedIds = [...selectedIds].filter((id) => {
-    const item = pageRows.find((tx) => tx.id === id);
-    return item && !item.isGroup && item.parentId === null;
-  });
+  const selectedUngrouped = [...selectedIds.values()].filter(
+    (tx) => !tx.isGroup && tx.parentId === null,
+  );
 
-  const clearSelected = () => setSelectedIds(new Set());
+  const clearSelected = () => setSelectedIds(new Map());
 
   const handleCreateGroup = async (name: string): Promise<string> => {
-    const children = selectedUngroupedIds.map(
-      (id) => allTransactions.find((tx) => tx.id === id)!,
-    );
+    const children = selectedUngrouped;
+    const childIds = children.map((tx) => tx.id);
     const groupInfo = computeGroupFields(children);
     const groupTx = {
       description: name,
@@ -272,18 +273,15 @@ const Home = () => {
     const createdGroup = await groupRes.json();
     const actualGroupId = createdGroup.id;
 
-    await Promise.all(
-      selectedUngroupedIds.map((id) =>
-        fetch(`/api/transactions/${id}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ parentId: actualGroupId }),
-        }),
-      ),
-    );
+    await fetch("/api/transactions", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ids: childIds, updates: { parentId: actualGroupId } }),
+    });
 
+    setCurrentPage(1);
     await fetchPage({
-      page: currentPage,
+      page: 1,
       search: debouncedSearch,
       sortBy: sortConfig?.key ?? null,
       sortDir: sortConfig?.direction ?? null,
@@ -294,23 +292,18 @@ const Home = () => {
   };
 
   const handleAddToGroup = (groupId: string) => {
-    if (selectedUngroupedIds.length === 0) return;
+    if (selectedUngrouped.length === 0) return;
 
-    const addedTransactions = selectedUngroupedIds
-      .map((id) => allTransactions.find((tx) => tx.id === id)!)
-      .filter(Boolean);
+    const addedTransactions = selectedUngrouped;
+    const childIds = addedTransactions.map((tx) => tx.id);
 
     clearSelected();
 
-    Promise.all(
-      selectedUngroupedIds.map((id) =>
-        fetch(`/api/transactions/${id}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ parentId: groupId }),
-        }),
-      ),
-    ).then(() => {
+    fetch("/api/transactions", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ids: childIds, updates: { parentId: groupId } }),
+    }).then(() => {
       if (childRows[groupId]) {
         const updatedChildren = [
           ...childRows[groupId],
@@ -418,7 +411,7 @@ const Home = () => {
     })
       .then((res) => res.json())
       .then((created: Transaction[]) => {
-        setSelectedIds(new Set(created.map((row) => row.id)));
+        setSelectedIds(new Map(created.map((row: Transaction) => [row.id, row])));
         setCurrentPage(1);
         fetchPage({
           page: 1,
@@ -491,14 +484,20 @@ const Home = () => {
             expandedIds={expandedIds}
             onToggleExpand={handleToggleExpand}
             selectedIds={selectedIds}
-            onToggleSelect={(id) =>
+            onToggleSelect={(tx) =>
               setSelectedIds((prev) => {
-                const s = new Set(prev);
-                s.has(id) ? s.delete(id) : s.add(id);
-                return s;
+                const next = new Map(prev);
+                next.has(tx.id) ? next.delete(tx.id) : next.set(tx.id, tx);
+                return next;
               })
             }
-            onSelectAll={(ids) => setSelectedIds(new Set(ids))}
+            onSelectAll={(txs) =>
+              setSelectedIds((prev) => {
+                const next = new Map(prev);
+                for (const tx of txs) next.set(tx.id, tx);
+                return next;
+              })
+            }
             onClearSelection={clearSelected}
             onCreateGroup={handleCreateGroup}
             onAddToGroup={handleAddToGroup}
@@ -508,6 +507,7 @@ const Home = () => {
             allGroups={allGroups}
             allCategories={allCategories}
             allSources={allSources}
+            currentPage={currentPage}
           />
         </div>
         <div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -213,7 +213,7 @@ const Home = () => {
 
   const clearSelected = () => setSelectedIds(new Set());
 
-  const handleCreateGroup = async (name: string) => {
+  const handleCreateGroup = async (name: string): Promise<string> => {
     const children = selectedUngroupedIds.map(
       (id) => allTransactions.find((tx) => tx.id === id)!,
     );
@@ -235,7 +235,7 @@ const Home = () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(groupTx),
     });
-    if (!groupRes.ok) return;
+    if (!groupRes.ok) return "";
 
     const createdGroup = await groupRes.json();
     const actualGroupId = createdGroup.id;
@@ -250,12 +250,14 @@ const Home = () => {
       ),
     );
 
-    fetchPage({
+    await fetchPage({
       page: currentPage,
       search: debouncedSearch,
       sortBy: sortConfig?.key ?? null,
       sortDir: sortConfig?.direction ?? null,
     });
+
+    return actualGroupId;
   };
 
   const handleAddToGroup = (groupId: string) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,9 @@ const Home = () => {
   const [sortConfig, setSortConfig] = useState<SortConfig | null>(null);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set([]));
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set([]));
+  const [allGroups, setAllGroups] = useState<Transaction[]>([]);
+  const [allCategories, setAllCategories] = useState<string[]>([]);
+  const [allSources, setAllSources] = useState<string[]>([]);
 
   const { data: session, isPending } = authClient.useSession();
   const router = useRouter();
@@ -69,6 +72,16 @@ const Home = () => {
     [session?.user?.id],
   );
 
+  const fetchMetadata = useCallback(async () => {
+    if (!session?.user?.id) return;
+    const res = await fetch("/api/transactions?metadata=true");
+    if (!res.ok) return;
+    const data = await res.json();
+    setAllGroups(data.groups);
+    setAllCategories(data.categories);
+    setAllSources(data.sources);
+  }, [session?.user?.id]);
+
   // Debounce search — reset to page 1 on new query
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -83,6 +96,7 @@ const Home = () => {
     if (!session?.user?.id) return;
     if (prevUserIdRef.current !== session.user.id) {
       prevUserIdRef.current = session.user.id;
+      fetchMetadata();
     }
     fetchPage({
       page: currentPage,
@@ -106,6 +120,15 @@ const Home = () => {
     setCurrentPage(1);
   };
 
+  const addMetadata = (updates: Partial<Transaction>) => {
+    if (updates.category && !allCategories.includes(updates.category)) {
+      setAllCategories((prev) => [...prev, updates.category!]);
+    }
+    if (updates.source && !allSources.includes(updates.source)) {
+      setAllSources((prev) => [...prev, updates.source!]);
+    }
+  };
+
   const handleAddTransaction = (
     newTransaction: Omit<Transaction, "id" | "createdAt">,
   ) => {
@@ -121,6 +144,7 @@ const Home = () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(transaction),
     }).then(() => {
+      addMetadata(newTransaction);
       setCurrentPage(1);
       // If already on page 1, currentPage state won't change so trigger manually
       fetchPage({
@@ -155,6 +179,10 @@ const Home = () => {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(updates),
+    }).then(() => {
+      if (updates.category !== undefined || updates.source !== undefined) {
+        fetchMetadata();
+      }
     });
   };
 
@@ -162,6 +190,9 @@ const Home = () => {
     fetch(`/api/transactions/${id}`, {
       method: "DELETE",
     }).then(() => {
+      if (allGroups.some((g) => g.id === id)) {
+        setAllGroups((prev) => prev.filter((g) => g.id !== id));
+      }
       const isLastOnPage = pageRows.length === 1 && currentPage > 1;
       const nextPage = isLastOnPage ? currentPage - 1 : currentPage;
       setChildRows((prev) => {
@@ -175,6 +206,7 @@ const Home = () => {
         sortBy: sortConfig?.key ?? null,
         sortDir: sortConfig?.direction ?? null,
       });
+      fetchMetadata();
       if (isLastOnPage) setCurrentPage(nextPage);
     });
 
@@ -256,6 +288,7 @@ const Home = () => {
       sortBy: sortConfig?.key ?? null,
       sortDir: sortConfig?.direction ?? null,
     });
+    setAllGroups((prev) => [createdGroup, ...prev]);
 
     return actualGroupId;
   };
@@ -392,6 +425,10 @@ const Home = () => {
         }),
       ),
     ).then(() => {
+      // import doesn't have categories or source 
+      // for (const tx of newTransactions) {
+      //   trackMetadata(tx);
+      // }
       setCurrentPage(1);
       fetchPage({
         page: 1,
@@ -478,6 +515,9 @@ const Home = () => {
             onUnlinkChild={handleUnlinkChild}
             onBulkDelete={handleBulkDelete}
             onBulkUpdate={handleBulkUpdate}
+            allGroups={allGroups}
+            allCategories={allCategories}
+            allSources={allSources}
           />
         </div>
         <div>
@@ -494,13 +534,6 @@ const Home = () => {
           isOpen={isImportModalOpen}
           onClose={() => setIsImportModalOpen(false)}
           onImport={handleImportTransactions}
-          sourceSuggestions={[
-            ...new Set(
-              allTransactions
-                .map((t) => t.source)
-                .filter((s): s is string => s !== null),
-            ),
-          ]}
         />
       </div>
     </main>

--- a/components/BulkActions.tsx
+++ b/components/BulkActions.tsx
@@ -5,7 +5,7 @@ import { ChevronDown, ChevronRight, Trash } from "lucide-react";
 import { Transaction, STATUSES } from "@/types/transaction";
 
 interface BulkActionsProps {
-  selectedIds: Set<string>;
+  selectedIds: Map<string, Transaction>;
   onBulkDelete: (ids: string[]) => void;
   onBulkUpdate: (ids: string[], updates: Partial<Transaction>) => void;
   onClearSelection: () => void;
@@ -31,7 +31,7 @@ const BulkActions = ({
   const [hoveredItem, setHoveredItem] = useState<HoveredItem>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const ids = [...selectedIds];
+  const ids = [...selectedIds.keys()];
 
   const categorySuggestions = allCategories;
   const sourceSuggestions = allSources;

--- a/components/BulkActions.tsx
+++ b/components/BulkActions.tsx
@@ -54,7 +54,7 @@ const BulkActions = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  if (selectedIds.size === 0) return null;
+  const disabled = selectedIds.size === 0;
 
   const closeAll = () => {
     setOpen(false);
@@ -68,7 +68,7 @@ const BulkActions = ({
           setOpen(!open);
           setHoveredItem(null);
         }}
-        className="inline-flex items-center gap-1 px-2.5 py-1 text-[12px] font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors"
+        className="inline-flex items-center gap-1 px-2.5 h-6 text-[12px] font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors cursor-pointer"
       >
         Actions
         <ChevronDown className="w-3 h-3" />
@@ -96,6 +96,7 @@ const BulkActions = ({
                     <button
                       key={c}
                       onClick={() => {
+                        if (disabled) return;
                         onBulkUpdate(ids, { category: c });
                         closeAll();
                       }}
@@ -132,6 +133,7 @@ const BulkActions = ({
                   <button
                     key={s}
                     onClick={() => {
+                      if (disabled) return;
                       onBulkUpdate(ids, { status: s });
                       closeAll();
                     }}
@@ -164,6 +166,7 @@ const BulkActions = ({
                     <button
                       key={s}
                       onClick={() => {
+                        if (disabled) return;
                         onBulkUpdate(ids, { source: s });
                         closeAll();
                       }}
@@ -189,6 +192,7 @@ const BulkActions = ({
           <button
             onMouseEnter={() => setHoveredItem(null)}
             onClick={() => {
+              if (disabled) return;
               onBulkDelete(ids);
               closeAll();
             }}

--- a/components/BulkActions.tsx
+++ b/components/BulkActions.tsx
@@ -96,7 +96,7 @@ const BulkActions = ({
                         onAddToGroup(g.id);
                         closeAll();
                       }}
-                      className="w-full text-left px-3 py-1.5 text-[13px] text-gray-700 hover:bg-gray-50 transition-colors truncate"
+                      className="w-full text-left px-3 py-1.5 text-[13px] text-gray-700 hover:bg-gray-50 transition-colors truncate uppercase"
                     >
                       {g.description}
                     </button>

--- a/components/BulkActions.tsx
+++ b/components/BulkActions.tsx
@@ -6,20 +6,26 @@ import { Transaction, STATUSES } from "@/types/transaction";
 
 interface BulkActionsProps {
   selectedIds: Set<string>;
-  allTransactions: Transaction[];
   onBulkDelete: (ids: string[]) => void;
   onBulkUpdate: (ids: string[], updates: Partial<Transaction>) => void;
   onClearSelection: () => void;
+  onAddToGroup: (groupId: string) => void;
+  allGroups: Transaction[];
+  allCategories: string[];
+  allSources: string[];
 }
 
-type HoveredItem = "category" | "status" | "source" | null;
+type HoveredItem = "category" | "status" | "source" | "group" | null;
 
 const BulkActions = ({
   selectedIds,
-  allTransactions,
   onBulkDelete,
   onBulkUpdate,
   onClearSelection,
+  onAddToGroup,
+  allGroups,
+  allCategories,
+  allSources,
 }: BulkActionsProps) => {
   const [open, setOpen] = useState(false);
   const [hoveredItem, setHoveredItem] = useState<HoveredItem>(null);
@@ -27,18 +33,8 @@ const BulkActions = ({
 
   const ids = [...selectedIds];
 
-  const categorySuggestions = [
-    ...new Set(
-      allTransactions.map((t) => t.category).filter(Boolean) as string[],
-    ),
-  ];
-  const sourceSuggestions = [
-    ...new Set(
-      allTransactions
-        .map((t) => t.source)
-        .filter((s): s is string => s !== null),
-    ),
-  ];
+  const categorySuggestions = allCategories;
+  const sourceSuggestions = allSources;
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -68,7 +64,7 @@ const BulkActions = ({
           setOpen(!open);
           setHoveredItem(null);
         }}
-        className="inline-flex items-center gap-1 px-2.5 h-6 text-[12px] font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors cursor-pointer"
+        className="inline-flex items-center gap-1 px-2.5 h-7 text-[12px] font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors cursor-pointer"
       >
         Actions
         <ChevronDown className="w-3 h-3" />
@@ -76,6 +72,44 @@ const BulkActions = ({
 
       {open && (
         <div className="absolute left-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1">
+          {/* Group */}
+          <div
+            className="relative"
+            onMouseEnter={() => setHoveredItem("group")}
+          >
+            <button className="w-full text-left px-3 py-1.5 text-[13px] text-gray-700 hover:bg-gray-50 transition-colors flex items-center justify-between">
+              Group
+              <ChevronRight className="w-3 h-3 text-gray-400" />
+            </button>
+
+            {hoveredItem === "group" && (
+              <div
+                className="absolute left-full top-0 ml-1 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1 max-h-48 overflow-y-auto"
+                onMouseEnter={() => setHoveredItem("group")}
+              >
+                {allGroups.length > 0 ? (
+                  allGroups.map((g) => (
+                    <button
+                      key={g.id}
+                      onClick={() => {
+                        if (disabled) return;
+                        onAddToGroup(g.id);
+                        closeAll();
+                      }}
+                      className="w-full text-left px-3 py-1.5 text-[13px] text-gray-700 hover:bg-gray-50 transition-colors truncate"
+                    >
+                      {g.description}
+                    </button>
+                  ))
+                ) : (
+                  <span className="px-3 py-1.5 text-[12px] text-gray-400 block">
+                    No groups yet
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+
           {/* Category */}
           <div
             className="relative"
@@ -88,7 +122,7 @@ const BulkActions = ({
 
             {hoveredItem === "category" && (
               <div
-                className="absolute left-full top-0 ml-1 w-40 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1"
+                className="absolute left-full top-0 ml-1 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1 max-h-48 overflow-y-auto"
                 onMouseEnter={() => setHoveredItem("category")}
               >
                 {categorySuggestions.length > 0 ? (
@@ -158,7 +192,7 @@ const BulkActions = ({
 
             {hoveredItem === "source" && (
               <div
-                className="absolute left-full top-0 ml-1 w-40 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1"
+                className="absolute left-full top-0 ml-1 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1 max-h-48 overflow-y-auto"
                 onMouseEnter={() => setHoveredItem("source")}
               >
                 {sourceSuggestions.length > 0 ? (

--- a/components/CSVImportModal.tsx
+++ b/components/CSVImportModal.tsx
@@ -2,13 +2,11 @@ import React, { useRef, useState, useEffect } from "react";
 import { Transaction, Status } from "@/types/transaction";
 import { Upload, X } from "lucide-react";
 import { CSV_PRESETS, CSVPreset } from "@/lib/csvPresets";
-import InputAutocomplete from "@/components/InputAutocomplete";
 
 interface CSVImportModalProps {
   isOpen: boolean;
   onClose: () => void;
   onImport: (transactions: Omit<Transaction, "id" | "createdAt">[]) => void;
-  sourceSuggestions: string[];
 }
 
 interface CSVData {
@@ -83,13 +81,11 @@ const CSVImportModal = ({
   isOpen,
   onClose,
   onImport,
-  sourceSuggestions,
 }: CSVImportModalProps) => {
   const [csvData, setCsvData] = useState<CSVData | null>(null);
   const [mapping, setMapping] = useState<Partial<Record<FieldKey, string>>>({});
   const [pendingField, setPendingField] = useState<FieldKey | null>(null);
   const [detectedPreset, setDetectedPreset] = useState<CSVPreset | null>(null);
-  const [source, setSource] = useState<string>("");
   const fileRef = useRef<HTMLInputElement>(null);
 
   //reset state when modal closes
@@ -100,7 +96,6 @@ const CSVImportModal = ({
         setMapping({});
         setPendingField(null);
         setDetectedPreset(null);
-        setSource("");
         if (fileRef.current) fileRef.current.value = ""; //get rid of uploaded file
       }, 200); //wait for transition
     }
@@ -183,15 +178,13 @@ const CSVImportModal = ({
   const handleConfirm = () => {
     if (!csvData) return;
 
-    const resolvedSource = source.trim() || null;
-
     if (detectedPreset) {
       const newTransactions = csvData.allRows
         .flatMap((row) => detectedPreset.mapRow(row, csvData.headers))
         .map((mapped) => ({
           ...mapped,
           status: "Completed" as Status,
-          source: resolvedSource,
+          source: null,
           isGroup: false,
           parentId: null,
         }));
@@ -238,7 +231,7 @@ const CSVImportModal = ({
         category: null,
         amount: isNaN(cleanAmount) ? 0 : cleanAmount,
         status: "Completed" as Status,
-        source: resolvedSource,
+        source: null,
         isGroup: false,
         parentId: null,
       };
@@ -308,15 +301,6 @@ const CSVImportModal = ({
               <h2 className="text-[15px] font-semibold text-gray-900 tracking-tight">
                 {detectedPreset.name} Detected
               </h2>
-              <div className="w-48">
-                <InputAutocomplete
-                  value={source}
-                  onChange={setSource}
-                  onCommit={setSource}
-                  suggestions={sourceSuggestions}
-                  placeholder="Source (optional)"
-                />
-              </div>
             </div>
 
             {/* Preset preview table */}
@@ -396,15 +380,6 @@ const CSVImportModal = ({
                   Click a field below, then click the matching column header in
                   the table preview.
                 </p>
-              </div>
-              <div className="w-48">
-                <InputAutocomplete
-                  value={source}
-                  onChange={setSource}
-                  onCommit={setSource}
-                  suggestions={sourceSuggestions}
-                  placeholder="Source (optional)"
-                />
               </div>
             </div>
             {/*Field Pills */}

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -29,9 +29,9 @@ interface TransactionTableProps {
   onCancelAdd: () => void;
   expandedIds: Set<string>;
   onToggleExpand: (id: string) => void;
-  selectedIds: Set<string>;
-  onToggleSelect: (id: string) => void;
-  onSelectAll: (ids: string[]) => void;
+  selectedIds: Map<string, Transaction>;
+  onToggleSelect: (tx: Transaction) => void;
+  onSelectAll: (txs: Transaction[]) => void;
   onClearSelection: () => void;
   onCreateGroup: (name: string) => Promise<string>;
   onAddToGroup: (groupId: string) => void;
@@ -41,6 +41,7 @@ interface TransactionTableProps {
   allGroups: Transaction[];
   allCategories: string[];
   allSources: string[];
+  currentPage: number;
 }
 
 const localToday = () => {
@@ -83,6 +84,7 @@ const TransactionTable = ({
   allGroups,
   allCategories,
   allSources,
+  currentPage,
 }: TransactionTableProps) => {
   const [newTransaction, setNewTransaction] = useState<Partial<Transaction>>({
     date: localToday(),
@@ -101,6 +103,11 @@ const TransactionTable = ({
   } | null>(null);
   const [editValue, setEditValue] = useState<string>("");
   const inputRef = useRef<HTMLInputElement | HTMLSelectElement | null>(null);
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    tableContainerRef.current?.scrollTo(0, 0);
+  }, [currentPage]);
 
   const allSuggestions = useMemo(() => {
     const used = allTransactions
@@ -126,12 +133,10 @@ const TransactionTable = ({
 
   const selectedUngroupedIds = useMemo(
     () =>
-      allTransactions
-        .filter(
-          (tx) => selectedIds.has(tx.id) && !tx.isGroup && tx.parentId === null,
-        )
+      [...selectedIds.values()]
+        .filter((tx) => !tx.isGroup && tx.parentId === null)
         .map((tx) => tx.id),
-    [allTransactions, selectedIds],
+    [selectedIds],
   );
 
   const existingGroups = useMemo(
@@ -174,19 +179,23 @@ const TransactionTable = ({
   const commitEdit = () => {
     if (!editingCell) return;
     const { id, field } = editingCell;
+    const tx = allTransactions.find((t) => t.id === id);
     if (field === "amount") {
       const parsed = parseFloat(editValue);
-      if (!isNaN(parsed)) onUpdate(id, { amount: parsed });
+      if (!isNaN(parsed) && parsed !== tx?.amount) onUpdate(id, { amount: parsed });
     } else if (field === "date") {
-      if (editValue) onUpdate(id, { date: editValue });
+      if (editValue && editValue !== tx?.date) onUpdate(id, { date: editValue });
     } else if (field === "description") {
-      if (editValue.trim()) onUpdate(id, { description: editValue.trim() });
+      const trimmed = editValue.trim();
+      if (trimmed && trimmed !== tx?.description) onUpdate(id, { description: trimmed });
     } else if (field === "category") {
-      onUpdate(id, { category: editValue.trim() || null });
+      const val = editValue.trim() || null;
+      if (val !== (tx?.category ?? null)) onUpdate(id, { category: val });
     } else if (field === "source") {
-      onUpdate(id, { source: editValue.trim() || null });
+      const val = editValue.trim() || null;
+      if (val !== (tx?.source ?? null)) onUpdate(id, { source: val });
     } else if (field === "status") {
-      onUpdate(id, { status: editValue as Status });
+      if (editValue !== tx?.status) onUpdate(id, { status: editValue as Status });
     }
     setEditingCell(null);
     setEditValue("");
@@ -278,7 +287,7 @@ const TransactionTable = ({
       {/* Toolbar — always reserves space to prevent table shift */}
       <div className="flex items-center gap-2 mb-3 flex-wrap h-8">
           <span className="text-[12px] text-gray-400 tabular-nums w-[70px] shrink-0">
-            {selectedUngroupedIds.length} selected
+            {selectedIds.size} selected
           </span>
           <button
             onClick={async () => {
@@ -303,7 +312,7 @@ const TransactionTable = ({
           />
       </div>
 
-      <div className="overflow-x-auto overflow-y-auto max-h-[calc(100vh-16rem)]">
+      <div ref={tableContainerRef} className="overflow-x-auto overflow-y-auto max-h-[calc(100vh-16rem)]">
         <table className="w-full text-left border-collapse">
           {/* Header */}
           <thead className="sticky top-0 bg-white z-2">
@@ -319,7 +328,7 @@ const TransactionTable = ({
                         if (allSelected) {
                           onClearSelection();
                         } else {
-                          onSelectAll(selectableIds);
+                          onSelectAll(transactions.filter((tx) => !tx.isGroup));
                         }
                       }}
                       className="w-3.5 h-3.5 accent-gray-700 cursor-pointer"
@@ -537,7 +546,7 @@ const TransactionTable = ({
                             <input
                               type="checkbox"
                               checked={isSelected}
-                              onChange={() => onToggleSelect(tx.id)}
+                              onChange={() => onToggleSelect(tx)}
                               className="w-3.5 h-3.5 accent-gray-700 cursor-pointer"
                             />
                           </label>

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -49,7 +49,6 @@ const localToday = () => {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 };
 
-
 const LOCKED_GROUP_FIELDS = new Set(["date", "amount", "status", "source"]);
 
 type EditableFields =
@@ -128,7 +127,9 @@ const TransactionTable = ({
     [transactions],
   );
 
-  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selectedIds.has(id));
+  const allSelected =
+    selectableIds.length > 0 &&
+    selectableIds.every((id) => selectedIds.has(id));
   const someSelected = selectableIds.some((id) => selectedIds.has(id));
 
   const selectedUngroupedIds = useMemo(
@@ -182,12 +183,15 @@ const TransactionTable = ({
     const tx = allTransactions.find((t) => t.id === id);
     if (field === "amount") {
       const parsed = parseFloat(editValue);
-      if (!isNaN(parsed) && parsed !== tx?.amount) onUpdate(id, { amount: parsed });
+      if (!isNaN(parsed) && parsed !== tx?.amount)
+        onUpdate(id, { amount: parsed });
     } else if (field === "date") {
-      if (editValue && editValue !== tx?.date) onUpdate(id, { date: editValue });
+      if (editValue && editValue !== tx?.date)
+        onUpdate(id, { date: editValue });
     } else if (field === "description") {
       const trimmed = editValue.trim();
-      if (trimmed && trimmed !== tx?.description) onUpdate(id, { description: trimmed });
+      if (trimmed && trimmed !== tx?.description)
+        onUpdate(id, { description: trimmed });
     } else if (field === "category") {
       const val = editValue.trim() || null;
       if (val !== (tx?.category ?? null)) onUpdate(id, { category: val });
@@ -195,7 +199,8 @@ const TransactionTable = ({
       const val = editValue.trim() || null;
       if (val !== (tx?.source ?? null)) onUpdate(id, { source: val });
     } else if (field === "status") {
-      if (editValue !== tx?.status) onUpdate(id, { status: editValue as Status });
+      if (editValue !== tx?.status)
+        onUpdate(id, { status: editValue as Status });
     }
     setEditingCell(null);
     setEditValue("");
@@ -277,8 +282,8 @@ const TransactionTable = ({
   const isEditing = (id: string, field: EditableFields) =>
     editingCell?.id === id && editingCell?.field === field;
 
-  const thClass = `py-3 px-4 font-normal text-[11px] uppercase tracking-wider text-gray-500 border-b border-gray-200 select-none`;
-  const tdClass = `py-2.5 px-4 text-[13px] border-b border-gray-100 whitespace-nowrap`;
+  const thClass = `h-9 px-4 font-normal text-[11px] uppercase tracking-wider text-gray-500 border-b border-gray-200 select-none`;
+  const tdClass = `h-9 px-4 text-[13px] border-b border-gray-100 whitespace-nowrap`;
   const addInputClass = `w-full bg-transparent border-0 border-b border-transparent hover:border-gray-200 focus:ring-0 p-1 text-[13px] text-gray-900 placeholder-gray-400 transition-colors outline-none`;
   const editInputClass = `w-full bg-transparent border-0 outline-none text-[13px] text-gray-900 p-0 m-0 focus:ring-0 caret-gray-400`;
 
@@ -286,33 +291,45 @@ const TransactionTable = ({
     <div className="w-full">
       {/* Toolbar — always reserves space to prevent table shift */}
       <div className="flex items-center gap-2 mb-3 flex-wrap h-8">
-          <span className="text-[12px] text-gray-400 tabular-nums w-[70px] shrink-0">
-            {selectedIds.size} selected
-          </span>
-          <button
-            onClick={async () => {
-              if (selectedUngroupedIds.length < 1) return;
-              const newGroupId = await onCreateGroup("New Group");
-              pendingFocusIdRef.current = newGroupId;
-            }}
-            className="flex items-center gap-1 px-2 h-7 text-[12px] text-white bg-gray-800 rounded transition-colors cursor-pointer"
-          >
-            <Layers className="w-3.5 h-3.5" />
-            Merge
-          </button>
-          <BulkActions
-            selectedIds={selectedIds}
-            onBulkDelete={onBulkDelete}
-            onBulkUpdate={onBulkUpdate}
-            onClearSelection={onClearSelection}
-            onAddToGroup={onAddToGroup}
-            allGroups={allGroups}
-            allCategories={allCategories}
-            allSources={allSources}
-          />
+        <span className="text-[12px] text-gray-400 tabular-nums w-18 shrink-0">
+          {selectedIds.size} selected
+        </span>
+        <button
+          onClick={async () => {
+            if (selectedUngroupedIds.length < 1) return;
+            const newGroupId = await onCreateGroup("New Group");
+            pendingFocusIdRef.current = newGroupId;
+          }}
+          className="flex items-center gap-1 px-2 h-7 text-[12px] text-white bg-gray-800 rounded transition-colors cursor-pointer"
+        >
+          <Layers className="w-3.5 h-3.5" />
+          Merge
+        </button>
+        <BulkActions
+          selectedIds={selectedIds}
+          onBulkDelete={onBulkDelete}
+          onBulkUpdate={onBulkUpdate}
+          onClearSelection={onClearSelection}
+          onAddToGroup={onAddToGroup}
+          allGroups={allGroups}
+          allCategories={allCategories}
+          allSources={allSources}
+        />
+        <button
+          onClick={() => {
+            onClearSelection();
+          }}
+          className="p-1.5 text-gray-400 hover:text-gray-700 transition-colors"
+          aria-label="Clear selection"
+        >
+          <X className="w-4 h-4" />
+        </button>
       </div>
 
-      <div ref={tableContainerRef} className="overflow-x-auto overflow-y-auto max-h-[calc(100vh-16rem)]">
+      <div
+        ref={tableContainerRef}
+        className="overflow-x-auto overflow-y-auto max-h-[calc(100vh-16rem)]"
+      >
         <table className="w-full text-left border-collapse">
           {/* Header */}
           <thead className="sticky top-0 bg-white z-2">
@@ -323,10 +340,14 @@ const TransactionTable = ({
                     <input
                       type="checkbox"
                       checked={allSelected}
-                      ref={(el) => { if (el) el.indeterminate = someSelected && !allSelected; }}
+                      ref={(el) => {
+                        if (el) el.indeterminate = someSelected && !allSelected;
+                      }}
                       onChange={() => {
                         if (allSelected) {
-                          onClearSelection();
+                          for (const tx of transactions) {
+                            if (!tx.isGroup) onToggleSelect(tx);
+                          }
                         } else {
                           onSelectAll(transactions.filter((tx) => !tx.isGroup));
                         }
@@ -379,8 +400,8 @@ const TransactionTable = ({
             {/* Add Transaction Row */}
             {showAddRow && (
               <tr className="bg-gray-50/50 border-b border-gray-200">
-                <td className="py-2 px-3" />
-                <td className="py-2 px-3">
+                <td className="h-9 px-3" />
+                <td className="h-9 px-3">
                   <input
                     type="date"
                     value={newTransaction.date}
@@ -394,7 +415,7 @@ const TransactionTable = ({
                     autoFocus
                   />
                 </td>
-                <td className="py-2 px-3">
+                <td className="h-9 px-3">
                   <input
                     type="text"
                     placeholder="Description..."
@@ -408,7 +429,7 @@ const TransactionTable = ({
                     }
                   />
                 </td>
-                <td className="py-2 px-3">
+                <td className="h-9 px-3">
                   <InputAutocomplete
                     value={newTransaction.category ?? ""}
                     onChange={(val) =>
@@ -422,7 +443,7 @@ const TransactionTable = ({
                     positionerZIndex={50}
                   />
                 </td>
-                <td className="py-2 px-3">
+                <td className="h-9 px-3">
                   <input
                     type="number"
                     placeholder="0.00"
@@ -437,7 +458,7 @@ const TransactionTable = ({
                     }
                   />
                 </td>
-                <td className="py-2 px-3">
+                <td className="h-9 px-3">
                   <select
                     value={newTransaction.status}
                     className={addInputClass}
@@ -455,7 +476,7 @@ const TransactionTable = ({
                     ))}
                   </select>
                 </td>
-                <td className="py-2 px-3">
+                <td className="h-9 px-3">
                   <InputAutocomplete
                     value={newTransaction.source ?? ""}
                     onChange={(val) =>
@@ -469,7 +490,7 @@ const TransactionTable = ({
                     positionerZIndex={50}
                   />
                 </td>
-                <td className="py-2 px-3 text-right">
+                <td className="py-1.5 px-3 text-right">
                   <div className="flex items-center justify-end gap-2">
                     <button
                       onClick={handleSaveNew}
@@ -609,10 +630,13 @@ const TransactionTable = ({
                           />
                         ) : (
                           <span className="flex items-center gap-1.5 py-px">
-                            <span>{tx.description}</span>
+                            <span className="uppercase">{tx.description}</span>
                             {tx.isGroup && tx.childCount !== undefined && (
                               <span className="text-gray-400 text-[11px] font-normal">
-                                · {tx.childCount} {tx.childCount === 1 ? "Transaction" : "Transactions"}
+                                · {tx.childCount}{" "}
+                                {tx.childCount === 1
+                                  ? "Transaction"
+                                  : "Transactions"}
                               </span>
                             )}
                           </span>
@@ -857,7 +881,9 @@ const TransactionTable = ({
                                 />
                               ) : (
                                 <span className="cursor-text block py-px">
-                                  {child.description}
+                                  <span className="uppercase">
+                                    {child.description}
+                                  </span>
                                 </span>
                               )}
                             </div>

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -38,6 +38,9 @@ interface TransactionTableProps {
   onUnlinkChild: (childId: string) => void;
   onBulkDelete: (ids: string[]) => void;
   onBulkUpdate: (ids: string[], updates: Partial<Transaction>) => void;
+  allGroups: Transaction[];
+  allCategories: string[];
+  allSources: string[];
 }
 
 const localToday = () => {
@@ -77,6 +80,9 @@ const TransactionTable = ({
   onUnlinkChild,
   onBulkDelete,
   onBulkUpdate,
+  allGroups,
+  allCategories,
+  allSources,
 }: TransactionTableProps) => {
   const [newTransaction, setNewTransaction] = useState<Partial<Transaction>>({
     date: localToday(),
@@ -280,17 +286,20 @@ const TransactionTable = ({
               const newGroupId = await onCreateGroup("New Group");
               pendingFocusIdRef.current = newGroupId;
             }}
-            className="flex items-center gap-1 px-2 h-6 text-[12px] text-white bg-gray-800 rounded transition-colors cursor-pointer"
+            className="flex items-center gap-1 px-2 h-7 text-[12px] text-white bg-gray-800 rounded transition-colors cursor-pointer"
           >
             <Layers className="w-3.5 h-3.5" />
             Merge
           </button>
           <BulkActions
             selectedIds={selectedIds}
-            allTransactions={allTransactions}
             onBulkDelete={onBulkDelete}
             onBulkUpdate={onBulkUpdate}
             onClearSelection={onClearSelection}
+            onAddToGroup={onAddToGroup}
+            allGroups={allGroups}
+            allCategories={allCategories}
+            allSources={allSources}
           />
       </div>
 

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -33,7 +33,7 @@ interface TransactionTableProps {
   onToggleSelect: (id: string) => void;
   onSelectAll: (ids: string[]) => void;
   onClearSelection: () => void;
-  onCreateGroup: (name: string) => void;
+  onCreateGroup: (name: string) => Promise<string>;
   onAddToGroup: (groupId: string) => void;
   onUnlinkChild: (childId: string) => void;
   onBulkDelete: (ids: string[]) => void;
@@ -88,7 +88,7 @@ const TransactionTable = ({
     isGroup: false,
     parentId: null,
   });
-  const [groupInput, setGroupInput] = useState("");
+  const pendingFocusIdRef = useRef<string | null>(null);
   const [editingCell, setEditingCell] = useState<{
     id: string;
     field: EditableFields;
@@ -132,6 +132,15 @@ const TransactionTable = ({
     () => transactions.filter((tx) => tx.isGroup),
     [transactions],
   );
+
+  useEffect(() => {
+    if (pendingFocusIdRef.current) {
+      const id = pendingFocusIdRef.current;
+      pendingFocusIdRef.current = null;
+      setEditingCell({ id, field: "description" });
+      setEditValue("New Group");
+    }
+  }, [transactions]);
 
   useEffect(() => {
     if (editingCell && inputRef.current) {
@@ -261,54 +270,28 @@ const TransactionTable = ({
   return (
     <div className="w-full">
       {/* Toolbar — always reserves space to prevent table shift */}
-      <div className={`flex items-center gap-2 mb-3 flex-wrap h-8 ${selectedIds.size === 0 ? "invisible" : ""}`}>
-          <span className="text-[12px] text-gray-400">
+      <div className="flex items-center gap-2 mb-3 flex-wrap h-8">
+          <span className="text-[12px] text-gray-400 tabular-nums w-[70px] shrink-0">
             {selectedUngroupedIds.length} selected
           </span>
-          {selectedUngroupedIds.length >= 1 && (
-            <>
-              <div className="flex items-center gap-1">
-                <InputAutocomplete
-                  value={groupInput}
-                  onChange={setGroupInput}
-                  suggestions={existingGroups.map((g) => g.description)}
-                  placeholder="Group as…"
-                  autoFocus={false}
-                  onCancel={() => setGroupInput("")}
-                  onCommit={(val) => {
-                    const trimmed = val.trim();
-                    if (!trimmed) return;
-                    const existing = existingGroups.find(
-                      (g) => g.description === trimmed,
-                    );
-                    if (existing) {
-                      onAddToGroup(existing.id);
-                    } else {
-                      onCreateGroup(trimmed);
-                    }
-                    setGroupInput("");
-                  }}
-                />
-              </div>
-              <BulkActions
-                selectedIds={selectedIds}
-                allTransactions={allTransactions}
-                onBulkDelete={onBulkDelete}
-                onBulkUpdate={onBulkUpdate}
-                onClearSelection={onClearSelection}
-              />
-            </>
-          )}
           <button
-            onClick={() => {
-              onClearSelection();
-              setGroupInput("");
+            onClick={async () => {
+              if (selectedUngroupedIds.length < 1) return;
+              const newGroupId = await onCreateGroup("New Group");
+              pendingFocusIdRef.current = newGroupId;
             }}
-            className="p-1.5 text-gray-400 hover:text-gray-700 transition-colors"
-            aria-label="Clear selection"
+            className="flex items-center gap-1 px-2 h-6 text-[12px] text-white bg-gray-800 rounded transition-colors cursor-pointer"
           >
-            <X className="w-4 h-4" />
+            <Layers className="w-3.5 h-3.5" />
+            Merge
           </button>
+          <BulkActions
+            selectedIds={selectedIds}
+            allTransactions={allTransactions}
+            onBulkDelete={onBulkDelete}
+            onBulkUpdate={onBulkUpdate}
+            onClearSelection={onClearSelection}
+          />
       </div>
 
       <div className="overflow-x-auto overflow-y-auto max-h-[calc(100vh-16rem)]">

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -2,6 +2,8 @@ export type Status = "Completed" | "Refunding" | "Owed";
 
 export const STATUSES: Status[] = ["Completed", "Owed", "Refunding"];
 
+export const UPDATABLE_FIELDS = ["date", "description", "category", "amount", "status", "source", "parentId"] as const;
+
 export type Category = string
 
 export type SortDirection = 'asc' | 'desc'


### PR DESCRIPTION
## Summary
- **Cross-page selection**: Selection state uses a `Map<string, Transaction>` so selections persist across pages. Header checkbox only deselects the current page.
- **Bulk API endpoints**: Added `PUT` and `DELETE` on `/api/transactions` for bulk operations, and `POST` now supports array bodies. Replaced all `Promise.all` loops with single bulk requests.
- **Metadata endpoint**: New `GET /api/transactions?metadata=true` returns all groups, distinct categories, and distinct sources in one call — no longer derived from current page data.
- **Merge UX overhaul**: Replaced the inline "Group as…" autocomplete with a one-click "Merge" button that creates a group and auto-focuses the name for editing. "Add to existing group" moved into the BulkActions dropdown.
- **Auto-select on CSV import**: Newly imported transactions are automatically selected after upload.
- **Scroll to top on page change**: Table scrolls to top when navigating pages.
- **Smarter edit commits**: Inline edits skip the API call if the value hasn't changed.
- **Styling**: Fixed row heights (`h-9`), uppercase descriptions, always-visible toolbar, removed source input from CSV modal, shared `UPDATABLE_FIELDS` constant.

## Test plan
- [x] Select transactions on page 1, navigate to page 2, select more — verify page 1 selections persist
- [x] Uncheck header checkbox on page 2 — verify only page 2 is deselected, page 1 stays selected
- [x] Click X to clear all — verify all selections across pages are cleared
- [x] Use "Merge" button — verify group is created and description field is focused for renaming
- [x] Use Actions > Group submenu to add to an existing group
- [x] Bulk update category/status/source via Actions dropdown
- [x] Bulk delete selected transactions
- [x] Import CSV — verify imported rows are auto-selected
- [x] Verify page change scrolls table to top
- [x] Edit a cell and blur without changing the value — verify no network request is made