### PR TITLE
29 redesign sign in

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
@@ -12,11 +12,6 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
-
-export const viewport: Viewport = {
-  width: "device-width",
-  initialScale: 1,
-};
 
 export const metadata: Metadata = {
   title: "ShowMeTheMoney",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
@@ -12,6 +12,11 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
 
 export const metadata: Metadata = {
   title: "ShowMeTheMoney",

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -46,7 +46,7 @@ export default function SignInPage() {
       loading={loading}
       onSubmit={handleSubmit}
       footer={
-        <p className="text-[14px] text-[#e3e3e3]">
+        <p className="text-[18px] text-[#e3e3e3]">
           New to ShowMeTheMoney?{" "}
           <a href="/sign-up" className="text-blue-400">
             Sign up

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
-import { Eye, EyeOff } from "lucide-react";
+import AuthLayout from "@/components/AuthLayout";
 
 export default function SignInPage() {
   const [email, setEmail] = useState("");
@@ -20,18 +20,10 @@ export default function SignInPage() {
 
     try {
       await authClient.signIn.email(
+        { email, password, rememberMe: false },
         {
-          email,
-          password,
-          rememberMe: false,
-        },
-        {
-          onError: (ctx) => {
-            setError(ctx.error.message);
-          },
-          onSuccess: () => {
-            router.replace("/");
-          },
+          onError: (ctx) => setError(ctx.error.message),
+          onSuccess: () => router.replace("/"),
         },
       );
     } catch {
@@ -42,125 +34,25 @@ export default function SignInPage() {
   };
 
   return (
-    <main className="min-h-screen bg-white dark:bg-[#131314] flex items-center justify-center">
-      <div className="w-full max-w-xs flex flex-col justify-center items-center">
-        {/* Header */}
-        <h1 className="pb-5 text-2xl font-semibold text-gray-900 dark:text-foreground">
-          Login to your account
-        </h1>
-        {/* Connect With */}
-        <div className="w-full flex flex-col justify-center text-center">
-          <div className="flex items-center gap-1.5 text-gray-600 dark:text-gray-400 text-[11px] mb-5">
-            <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
-            <p className="text-nowrap">Connect to ShowMeTheMoney with</p>
-            <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
-          </div>
-          <button
-            onClick={() =>
-              authClient.signIn.social({
-                provider: "google",
-                callbackURL: "/",
-              })
-            }
-            className="w-full inline-flex items-center justify-center gap-2 px-4 py-1 text-[11px] font-medium text-gray-900 dark:text-foreground border border-gray-400 dark:border-gray-500 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-800 transition-colors"
-          >
-            <GoogleIcon />
-            Google
-          </button>
-        </div>
-        {/* Form */}
-        <form
-          onSubmit={handleSubmit}
-          className="w-full py-5 flex flex-col gap-3"
-        >
-          <div className="flex items-center gap-1.5 text-gray-600 dark:text-gray-400 text-[11px] mb-2">
-            <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
-            <p className="text-nowrap">Or continue with Email</p>
-            <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[11px] text-gray-900 dark:text-foreground font-medium">
-              Email
-            </label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              placeholder="you@example.com"
-              className="w-full px-3 py-1 text-[11px] text-gray-900 dark:text-foreground bg-transparent dark:bg-neutral-900 border border-gray-400 dark:border-gray-500 rounded-md placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-gray-900 dark:focus:border-foreground transition-colors"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[11px] text-gray-900 dark:text-foreground font-medium">
-              Password
-            </label>
-            <div className="relative">
-              <input
-                type={showPassword ? "text" : "password"}
-                value={password}
-                placeholder="Enter a unique password"
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="w-full px-3 py-1 pr-10 text-[11px] text-gray-900 dark:text-foreground bg-transparent dark:bg-neutral-900 border border-gray-400 dark:border-gray-500 rounded-md placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-gray-900 dark:focus:border-foreground transition-colors"
-              />
-              <button
-                type="button"
-                onClick={() => setShowPassword((p) => !p)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-900 dark:text-foreground transition-colors"
-              >
-                {showPassword ? <Eye size={12} /> : <EyeOff size={12} />}
-              </button>
-            </div>
-          </div>
-
-          {error && (
-            <p className="text-[12px] text-rose-600 dark:text-rose-400">
-              {error}
-            </p>
-          )}
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="mt-2 w-full py-1 text-[11px] font-medium text-gray-900 dark:text-foreground bg-transparent border border-gray-400 dark:border-gray-500 rounded-md hover:bg-gray-200 dark:hover:bg-neutral-800 disabled:text-gray-400 dark:disabled:text-gray-500 disabled:cursor-not-allowed transition-colors"
-          >
-            {loading ? "Please wait…" : "Continue"}
-          </button>
-
-          <p className="text-[14px]">
-            New to ShowMeTheMoney? {""}
-            <a href="/sign-up" className="text-blue-400">
-              Sign up
-            </a>
-          </p>
-        </form>
-      </div>
-    </main>
-  );
-}
-
-function GoogleIcon() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-      <path
-        d="M15.68 8.18c0-.57-.05-1.11-.14-1.64H8v3.1h4.3a3.67 3.67 0 0 1-1.59 2.41v2h2.57c1.5-1.38 2.4-3.42 2.4-5.87Z"
-        fill="#4285F4"
-      />
-      <path
-        d="M8 16c2.16 0 3.97-.71 5.29-1.93l-2.57-2a4.8 4.8 0 0 1-7.16-2.52H.9v2.07A8 8 0 0 0 8 16Z"
-        fill="#34A853"
-      />
-      <path
-        d="M3.56 9.55A4.82 4.82 0 0 1 3.3 8c0-.54.09-1.06.25-1.55V4.38H.9A8.01 8.01 0 0 0 0 8c0 1.29.31 2.51.9 3.62l2.66-2.07Z"
-        fill="#FBBC05"
-      />
-      <path
-        d="M8 3.18c1.22 0 2.31.42 3.17 1.24l2.37-2.37A7.94 7.94 0 0 0 8 0 8 8 0 0 0 .9 4.38l2.66 2.07A4.77 4.77 0 0 1 8 3.18Z"
-        fill="#EA4335"
-      />
-    </svg>
+    <AuthLayout
+      title="Login to your account"
+      email={email}
+      setEmail={setEmail}
+      password={password}
+      setPassword={setPassword}
+      showPassword={showPassword}
+      setShowPassword={setShowPassword}
+      error={error}
+      loading={loading}
+      onSubmit={handleSubmit}
+      footer={
+        <p className="text-[14px] text-[#e3e3e3]">
+          New to ShowMeTheMoney?{" "}
+          <a href="/sign-up" className="text-blue-400">
+            Sign up
+          </a>
+        </p>
+      }
+    />
   );
 }

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -39,14 +39,14 @@ export default function SignUpPage() {
       title="Create your account"
       extraFields={
         <div className="flex flex-col gap-1.5">
-          <label className="text-[11px] text-[#e3e3e3] font-medium">Name</label>
+          <label className="text-[15px] text-[#e3e3e3] font-medium">Name</label>
           <input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
             placeholder="John Doe"
-            className="w-full px-3 py-1 text-[11px] text-[#e3e3e3] bg-neutral-900 border border-gray-500 rounded-md placeholder-gray-500 focus:outline-none focus:border-[#e3e3e3] transition-colors"
+            className="w-full px-3 py-1 text-[15px] text-[#e3e3e3] bg-neutral-900 border border-gray-500 rounded-md placeholder-gray-500 focus:outline-none focus:border-[#e3e3e3] transition-colors"
           />
         </div>
       }
@@ -61,7 +61,7 @@ export default function SignUpPage() {
       onSubmit={handleSubmit}
       footer={
         <>
-          <p className="text-[10px] text-[#e3e3e3]">
+          <p className="text-[15px] text-[#e3e3e3]">
             By creating an account you agree to the{" "}
             <a href="" className="underline">
               Terms of Service
@@ -72,7 +72,7 @@ export default function SignUpPage() {
             </a>
             .
           </p>
-          <p className="text-[14px] text-[#e3e3e3]">
+          <p className="text-[18px] text-[#e3e3e3]">
             Already have an account?{" "}
             <a href="/sign-in" className="text-blue-400">
               Login

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
-import { Eye, EyeOff } from "lucide-react";
+import AuthLayout from "@/components/AuthLayout";
 
-export default function SignInPage() {
+export default function SignUpPage() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -21,18 +21,10 @@ export default function SignInPage() {
 
     try {
       await authClient.signUp.email(
+        { name, email, password },
         {
-          name,
-          email,
-          password,
-        },
-        {
-          onError: (ctx) => {
-            setError(ctx.error.message ?? "Sign up failed");
-          },
-          onSuccess: () => {
-            router.replace("/");
-          },
+          onError: (ctx) => setError(ctx.error.message ?? "Sign up failed"),
+          onSuccess: () => router.replace("/"),
         },
       );
     } catch {
@@ -43,109 +35,33 @@ export default function SignInPage() {
   };
 
   return (
-    <main className="min-h-screen bg-white dark:bg-[#131314] flex items-center justify-center">
-      <div className="w-full max-w-xs flex flex-col justify-center items-center">
-        {/* Header */}
-        <h1 className="pb-5 text-2xl font-semibold text-gray-900 dark:text-foreground">
-          Create your account
-        </h1>
-        {/* Connect With */}
-        <div className="w-full flex flex-col justify-center text-center">
-          <div className="flex items-center gap-1.5 text-gray-600 dark:text-gray-400 text-[11px] mb-5">
-            <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
-            <p className="text-nowrap">Connect to ShowMeTheMoney with</p>
-            <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
-          </div>
-          <button
-            onClick={() =>
-              authClient.signIn.social({
-                provider: "google",
-                callbackURL: "/",
-              })
-            }
-            className="w-full inline-flex items-center justify-center gap-2 px-4 py-1 text-[11px] font-medium text-gray-900 dark:text-foreground border border-gray-400 dark:border-gray-500 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-800 transition-colors shadow-sm"
-          >
-            <GoogleIcon />
-            Google
-          </button>
+    <AuthLayout
+      title="Create your account"
+      extraFields={
+        <div className="flex flex-col gap-1.5">
+          <label className="text-[11px] text-[#e3e3e3] font-medium">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            placeholder="John Doe"
+            className="w-full px-3 py-1 text-[11px] text-[#e3e3e3] bg-neutral-900 border border-gray-500 rounded-md placeholder-gray-500 focus:outline-none focus:border-[#e3e3e3] transition-colors"
+          />
         </div>
-        {/* Form */}
-        <form
-          onSubmit={handleSubmit}
-          className="w-full py-5 flex flex-col gap-3"
-        >
-          <div className="flex items-center gap-1.5 text-gray-600 dark:text-gray-400 text-[11px] mb-2">
-            <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
-            <p className="text-nowrap">Or continue with Email</p>
-            <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[11px] text-gray-900 dark:text-foreground font-medium">
-              Name
-            </label>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-              placeholder="John Doe"
-              className="w-full px-3 py-1 text-[11px] text-gray-900 dark:text-foreground bg-transparent dark:bg-neutral-900 border border-gray-400 dark:border-gray-500 rounded-md placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-gray-900 dark:focus:border-foreground transition-colors"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[11px] text-gray-900 dark:text-foreground font-medium">
-              Email
-            </label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              placeholder="you@example.com"
-              className="w-full px-3 py-1 text-[11px] text-gray-900 dark:text-foreground bg-transparent dark:bg-neutral-900 border border-gray-400 dark:border-gray-500 rounded-md placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-gray-900 dark:focus:border-foreground transition-colors"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[11px] text-gray-900 dark:text-foreground font-medium">
-              Password
-            </label>
-            <div className="relative">
-              <input
-                type={showPassword ? "text" : "password"}
-                value={password}
-                placeholder="Enter a unique password"
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="w-full px-3 py-1 pr-10 text-[11px] text-gray-900 dark:text-foreground bg-transparent dark:bg-neutral-900 border border-gray-400 dark:border-gray-500 rounded-md placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-gray-900 dark:focus:border-foreground transition-colors"
-              />
-              <button
-                type="button"
-                onClick={() => setShowPassword((p) => !p)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-900 dark:text-foreground transition-colors"
-              >
-                {showPassword ? <Eye size={12} /> : <EyeOff size={12} />}
-              </button>
-            </div>
-          </div>
-
-          {error && (
-            <p className="text-[12px] text-rose-600 dark:text-rose-400">
-              {error}
-            </p>
-          )}
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="mt-2 w-full py-1 text-[11px] font-medium text-gray-900 dark:text-foreground bg-transparent border border-gray-400 dark:border-gray-500 rounded-md hover:bg-gray-200 dark:hover:bg-neutral-800 disabled:text-gray-400 dark:disabled:text-gray-500 disabled:cursor-not-allowed transition-colors"
-          >
-            {loading ? "Please wait…" : "Continue"}
-          </button>
-
-          <p className="text-[10px]">
+      }
+      email={email}
+      setEmail={setEmail}
+      password={password}
+      setPassword={setPassword}
+      showPassword={showPassword}
+      setShowPassword={setShowPassword}
+      error={error}
+      loading={loading}
+      onSubmit={handleSubmit}
+      footer={
+        <>
+          <p className="text-[10px] text-[#e3e3e3]">
             By creating an account you agree to the{" "}
             <a href="" className="underline">
               Terms of Service
@@ -156,38 +72,14 @@ export default function SignInPage() {
             </a>
             .
           </p>
-
-          <p className="text-[14px]">
+          <p className="text-[14px] text-[#e3e3e3]">
             Already have an account?{" "}
             <a href="/sign-in" className="text-blue-400">
               Login
             </a>
           </p>
-        </form>
-      </div>
-    </main>
-  );
-}
-
-function GoogleIcon() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-      <path
-        d="M15.68 8.18c0-.57-.05-1.11-.14-1.64H8v3.1h4.3a3.67 3.67 0 0 1-1.59 2.41v2h2.57c1.5-1.38 2.4-3.42 2.4-5.87Z"
-        fill="#4285F4"
-      />
-      <path
-        d="M8 16c2.16 0 3.97-.71 5.29-1.93l-2.57-2a4.8 4.8 0 0 1-7.16-2.52H.9v2.07A8 8 0 0 0 8 16Z"
-        fill="#34A853"
-      />
-      <path
-        d="M3.56 9.55A4.82 4.82 0 0 1 3.3 8c0-.54.09-1.06.25-1.55V4.38H.9A8.01 8.01 0 0 0 0 8c0 1.29.31 2.51.9 3.62l2.66-2.07Z"
-        fill="#FBBC05"
-      />
-      <path
-        d="M8 3.18c1.22 0 2.31.42 3.17 1.24l2.37-2.37A7.94 7.94 0 0 0 8 0 8 8 0 0 0 .9 4.38l2.66 2.07A4.77 4.77 0 0 1 8 3.18Z"
-        fill="#EA4335"
-      />
-    </svg>
+        </>
+      }
+    />
   );
 }

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -6,6 +6,7 @@ import { authClient } from "@/lib/auth-client";
 import { Eye, EyeOff } from "lucide-react";
 
 export default function SignInPage() {
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -19,15 +20,15 @@ export default function SignInPage() {
     setLoading(true);
 
     try {
-      await authClient.signIn.email(
+      await authClient.signUp.email(
         {
+          name,
           email,
           password,
-          rememberMe: false,
         },
         {
           onError: (ctx) => {
-            setError(ctx.error.message);
+            setError(ctx.error.message ?? "Sign up failed");
           },
           onSuccess: () => {
             router.replace("/");
@@ -46,7 +47,7 @@ export default function SignInPage() {
       <div className="w-full max-w-xs flex flex-col justify-center items-center">
         {/* Header */}
         <h1 className="pb-5 text-2xl font-semibold text-gray-900 dark:text-foreground">
-          Login to your account
+          Create your account
         </h1>
         {/* Connect With */}
         <div className="w-full flex flex-col justify-center text-center">
@@ -62,7 +63,7 @@ export default function SignInPage() {
                 callbackURL: "/",
               })
             }
-            className="w-full inline-flex items-center justify-center gap-2 px-4 py-1 text-[11px] font-medium text-gray-900 dark:text-foreground border border-gray-400 dark:border-gray-500 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-800 transition-colors"
+            className="w-full inline-flex items-center justify-center gap-2 px-4 py-1 text-[11px] font-medium text-gray-900 dark:text-foreground border border-gray-400 dark:border-gray-500 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-800 transition-colors shadow-sm"
           >
             <GoogleIcon />
             Google
@@ -77,6 +78,20 @@ export default function SignInPage() {
             <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
             <p className="text-nowrap">Or continue with Email</p>
             <div className="h-px w-full bg-gray-600 dark:bg-gray-400"></div>{" "}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-[11px] text-gray-900 dark:text-foreground font-medium">
+              Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              placeholder="John Doe"
+              className="w-full px-3 py-1 text-[11px] text-gray-900 dark:text-foreground bg-transparent dark:bg-neutral-900 border border-gray-400 dark:border-gray-500 rounded-md placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-gray-900 dark:focus:border-foreground transition-colors"
+            />
           </div>
 
           <div className="flex flex-col gap-1.5">
@@ -130,10 +145,22 @@ export default function SignInPage() {
             {loading ? "Please wait…" : "Continue"}
           </button>
 
+          <p className="text-[10px]">
+            By creating an account you agree to the{" "}
+            <a href="" className="underline">
+              Terms of Service
+            </a>{" "}
+            and our{" "}
+            <a href="" className="underline">
+              Privacy Policy
+            </a>
+            .
+          </p>
+
           <p className="text-[14px]">
-            New to ShowMeTheMoney? {""}
-            <a href="/sign-up" className="text-blue-400">
-              Sign up
+            Already have an account?{" "}
+            <a href="/sign-in" className="text-blue-400">
+              Login
             </a>
           </p>
         </form>

--- a/components/AuthLayout.tsx
+++ b/components/AuthLayout.tsx
@@ -34,19 +34,18 @@ export default function AuthLayout({
 }: AuthLayoutProps) {
   return (
     <main className="min-h-screen bg-[#131314] flex items-center justify-center">
-      <div className="w-full max-w-xs flex flex-col justify-center items-center">
-        <h1 className="pb-5 text-2xl font-semibold text-[#e3e3e3]">
-          {title}
-        </h1>
+      <div className="w-full max-w-xs flex flex-col justify-center items-center gap-5">
+        {/* Header */}
+        <h1 className="text-3xl font-semibold text-[#e3e3e3]">{title}</h1>
 
         {/* Google */}
-        <div className="w-full flex flex-col justify-center text-center">
+        <div className="w-full flex flex-col justify-center text-center gap-7">
           <Divider label="Connect to ShowMeTheMoney with" />
           <button
             onClick={() =>
               authClient.signIn.social({ provider: "google", callbackURL: "/" })
             }
-            className="w-full inline-flex items-center justify-center gap-2 px-4 py-1 text-[11px] font-medium text-[#e3e3e3] border border-gray-500 rounded-md hover:bg-neutral-800 transition-colors"
+            className="w-full inline-flex items-center justify-center gap-2 px-4 py-1 text-[15px] font-medium text-[#e3e3e3] border border-gray-500 rounded-md hover:bg-neutral-800 transition-colors"
           >
             <GoogleIcon />
             Google
@@ -54,64 +53,57 @@ export default function AuthLayout({
         </div>
 
         {/* Form */}
-        <form onSubmit={onSubmit} className="w-full py-5 flex flex-col gap-3">
-          <Divider label="Or continue with Email" className="mb-2" />
 
-          {extraFields}
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[11px] text-[#e3e3e3] font-medium">
-              Email
-            </label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              placeholder="you@example.com"
-              className="w-full px-3 py-1 text-[11px] text-[#e3e3e3] bg-neutral-900 border border-gray-500 rounded-md placeholder-gray-500 focus:outline-none focus:border-[#e3e3e3] transition-colors"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[11px] text-[#e3e3e3] font-medium">
-              Password
-            </label>
-            <div className="relative">
+        <div className="w-full flex flex-col gap-7">
+          <Divider label="Or continue with Email" />
+          <form onSubmit={onSubmit} className="w-full flex flex-col gap-3">
+            {extraFields}
+            <div className="flex flex-col gap-1.5">
+              <label className="text-[15px] text-[#e3e3e3] font-medium">
+                Email
+              </label>
               <input
-                type={showPassword ? "text" : "password"}
-                value={password}
-                placeholder="Enter a unique password"
-                onChange={(e) => setPassword(e.target.value)}
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
                 required
-                className="w-full px-3 py-1 pr-10 text-[11px] text-[#e3e3e3] bg-neutral-900 border border-gray-500 rounded-md placeholder-gray-500 focus:outline-none focus:border-[#e3e3e3] transition-colors"
+                placeholder="you@example.com"
+                className="w-full px-3 py-1 text-[15px] text-[#e3e3e3] bg-neutral-900 border border-gray-500 rounded-md placeholder-gray-500 focus:outline-none focus:border-[#e3e3e3] transition-colors"
               />
-              <button
-                type="button"
-                onClick={() => setShowPassword((p) => !p)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-[#e3e3e3] transition-colors"
-              >
-                {showPassword ? <Eye size={12} /> : <EyeOff size={12} />}
-              </button>
             </div>
-          </div>
-
-          {error && (
-            <p className="text-[12px] text-rose-400">
-              {error}
-            </p>
-          )}
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="mt-2 w-full py-1 text-[11px] font-medium text-[#e3e3e3] bg-transparent border border-gray-500 rounded-md hover:bg-neutral-800 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors"
-          >
-            {loading ? "Please wait…" : "Continue"}
-          </button>
-
-          {footer}
-        </form>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-[15px] text-[#e3e3e3] font-medium">
+                Password
+              </label>
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  placeholder="Enter a unique password"
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  className="w-full px-3 py-1 pr-10 text-[15px] text-[#e3e3e3] bg-neutral-900 border border-gray-500 rounded-md placeholder-gray-500 focus:outline-none focus:border-[#e3e3e3] transition-colors"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((p) => !p)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[#e3e3e3] transition-colors"
+                >
+                  {showPassword ? <Eye size={12} /> : <EyeOff size={12} />}
+                </button>
+              </div>
+            </div>
+            {error && <p className="text-[15px] text-rose-400">{error}</p>}
+            <button
+              type="submit"
+              disabled={loading}
+              className="mt-2 w-full py-1 text-[15px] font-medium text-[#e3e3e3] bg-transparent border border-gray-500 rounded-md hover:bg-neutral-800 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors"
+            >
+              {loading ? "Please wait…" : "Continue"}
+            </button>
+            {footer}
+          </form>
+        </div>
       </div>
     </main>
   );
@@ -126,7 +118,7 @@ function Divider({
 }) {
   return (
     <div
-      className={`flex items-center gap-1.5 text-gray-400 text-[11px] mb-5 ${className ?? ""}`}
+      className={`flex items-center gap-1.5 text-gray-400 text-[15px] ${className ?? ""}`}
     >
       <div className="h-px w-full bg-gray-400" />
       <p className="text-nowrap">{label}</p>

--- a/components/AuthLayout.tsx
+++ b/components/AuthLayout.tsx
@@ -109,17 +109,9 @@ export default function AuthLayout({
   );
 }
 
-function Divider({
-  label,
-  className,
-}: {
-  label: string;
-  className?: string;
-}) {
+function Divider({ label }: { label: string }) {
   return (
-    <div
-      className={`flex items-center gap-1.5 text-gray-400 text-[15px] ${className ?? ""}`}
-    >
+    <div className="flex items-center gap-1.5 text-gray-400 text-[15px]">
       <div className="h-px w-full bg-gray-400" />
       <p className="text-nowrap">{label}</p>
       <div className="h-px w-full bg-gray-400" />

--- a/components/AuthLayout.tsx
+++ b/components/AuthLayout.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { Eye, EyeOff } from "lucide-react";
+import { authClient } from "@/lib/auth-client";
+
+interface AuthLayoutProps {
+  title: string;
+  extraFields?: React.ReactNode;
+  email: string;
+  setEmail: (v: string) => void;
+  password: string;
+  setPassword: (v: string) => void;
+  showPassword: boolean;
+  setShowPassword: React.Dispatch<React.SetStateAction<boolean>>;
+  error: string;
+  loading: boolean;
+  onSubmit: (e: React.SubmitEvent<HTMLFormElement>) => void;
+  footer: React.ReactNode;
+}
+
+export default function AuthLayout({
+  title,
+  extraFields,
+  email,
+  setEmail,
+  password,
+  setPassword,
+  showPassword,
+  setShowPassword,
+  error,
+  loading,
+  onSubmit,
+  footer,
+}: AuthLayoutProps) {
+  return (
+    <main className="min-h-screen bg-[#131314] flex items-center justify-center">
+      <div className="w-full max-w-xs flex flex-col justify-center items-center">
+        <h1 className="pb-5 text-2xl font-semibold text-[#e3e3e3]">
+          {title}
+        </h1>
+
+        {/* Google */}
+        <div className="w-full flex flex-col justify-center text-center">
+          <Divider label="Connect to ShowMeTheMoney with" />
+          <button
+            onClick={() =>
+              authClient.signIn.social({ provider: "google", callbackURL: "/" })
+            }
+            className="w-full inline-flex items-center justify-center gap-2 px-4 py-1 text-[11px] font-medium text-[#e3e3e3] border border-gray-500 rounded-md hover:bg-neutral-800 transition-colors"
+          >
+            <GoogleIcon />
+            Google
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={onSubmit} className="w-full py-5 flex flex-col gap-3">
+          <Divider label="Or continue with Email" className="mb-2" />
+
+          {extraFields}
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-[11px] text-[#e3e3e3] font-medium">
+              Email
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              placeholder="you@example.com"
+              className="w-full px-3 py-1 text-[11px] text-[#e3e3e3] bg-neutral-900 border border-gray-500 rounded-md placeholder-gray-500 focus:outline-none focus:border-[#e3e3e3] transition-colors"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-[11px] text-[#e3e3e3] font-medium">
+              Password
+            </label>
+            <div className="relative">
+              <input
+                type={showPassword ? "text" : "password"}
+                value={password}
+                placeholder="Enter a unique password"
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="w-full px-3 py-1 pr-10 text-[11px] text-[#e3e3e3] bg-neutral-900 border border-gray-500 rounded-md placeholder-gray-500 focus:outline-none focus:border-[#e3e3e3] transition-colors"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((p) => !p)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-[#e3e3e3] transition-colors"
+              >
+                {showPassword ? <Eye size={12} /> : <EyeOff size={12} />}
+              </button>
+            </div>
+          </div>
+
+          {error && (
+            <p className="text-[12px] text-rose-400">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="mt-2 w-full py-1 text-[11px] font-medium text-[#e3e3e3] bg-transparent border border-gray-500 rounded-md hover:bg-neutral-800 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading ? "Please wait…" : "Continue"}
+          </button>
+
+          {footer}
+        </form>
+      </div>
+    </main>
+  );
+}
+
+function Divider({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`flex items-center gap-1.5 text-gray-400 text-[11px] mb-5 ${className ?? ""}`}
+    >
+      <div className="h-px w-full bg-gray-400" />
+      <p className="text-nowrap">{label}</p>
+      <div className="h-px w-full bg-gray-400" />
+    </div>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+      <path
+        d="M15.68 8.18c0-.57-.05-1.11-.14-1.64H8v3.1h4.3a3.67 3.67 0 0 1-1.59 2.41v2h2.57c1.5-1.38 2.4-3.42 2.4-5.87Z"
+        fill="#4285F4"
+      />
+      <path
+        d="M8 16c2.16 0 3.97-.71 5.29-1.93l-2.57-2a4.8 4.8 0 0 1-7.16-2.52H.9v2.07A8 8 0 0 0 8 16Z"
+        fill="#34A853"
+      />
+      <path
+        d="M3.56 9.55A4.82 4.82 0 0 1 3.3 8c0-.54.09-1.06.25-1.55V4.38H.9A8.01 8.01 0 0 0 0 8c0 1.29.31 2.51.9 3.62l2.66-2.07Z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M8 3.18c1.22 0 2.31.42 3.17 1.24l2.37-2.37A7.94 7.94 0 0 0 8 0 8 8 0 0 0 .9 4.38l2.66 2.07A4.77 4.77 0 0 1 8 3.18Z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -66,7 +66,7 @@ function getCorsHeaders(origin: string | null) {
 }
 
 // --- Public routes (no auth required) ---
-const publicPaths = ["/sign-in", "/api/auth"];
+const publicPaths = ["/sign-in", "/sign-up", "/api/auth"];
 
 function isPublicPath(pathname: string): boolean {
   return publicPaths.some(


### PR DESCRIPTION
## Redesign: Sign-in & Sign-up pages

### Overview

Replaced the old combined sign-in/sign-up tab UI with a dark-mode-first design split across two dedicated pages, backed by a shared `AuthLayout` component.

---

### New files

- **`components/AuthLayout.tsx`** — Shared layout for both auth pages. Renders the page shell, Google OAuth button, email/password form, show/hide password toggle, and a `footer` slot. Accepts an optional `extraFields` slot rendered above the email field (used by sign-up for the Name input).
- **`app/sign-up/page.tsx`** — Dedicated sign-up page using `AuthLayout`, with a Name field passed via `extraFields` and a footer linking back to sign-in.

---

### Modified files

#### `app/sign-in/page.tsx`
- Removed the old tabbed sign-in/sign-up single-page component
- Migrated to `AuthLayout` — sign-in logic only, no tab state
- Footer now links to `/sign-up`

---

### Design changes

| Before | After |
|--------|-------|
| Light mode default, dark mode via `dark:` classes | Dark mode as the default (`bg-[#131314]`) |
| Tabbed single page (sign-in + sign-up toggled) | Two separate routes: `/sign-in` and `/sign-up` |
| Small `text-[11px]`/`text-[13px]` labels | Larger `text-[15px]`–`text-[18px]` throughout |
| Compact card with border/shadow | Full-screen centered layout, no card |
| Inline "or" divider | Labeled `Divider` component with full-width rules |