### PR TITLE
32 add totals row at the end of the table

### DIFF
--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,7 +1,7 @@
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { transactions } from "@/lib/db/schema";
-import { eq, desc, asc, and, isNull, ilike, or, count, inArray, gte, lte, SQL } from "drizzle-orm";
+import { eq, desc, asc, and, isNull, ilike, or, count, sum, inArray, gte, lte, SQL } from "drizzle-orm";
 import { STATUSES, UPDATABLE_FIELDS } from "@/types/transaction";
 
 const SORTABLE_COLUMNS = {
@@ -126,7 +126,7 @@ export async function GET(request: Request) {
     orderByClause = desc(transactions.createdAt);
   }
 
-  const [data, countResult] = await Promise.all([
+  const [data, countResult, sumResult] = await Promise.all([
     db
       .select()
       .from(transactions)
@@ -135,9 +135,11 @@ export async function GET(request: Request) {
       .limit(limit)
       .offset(offset),
     db.select({ total: count() }).from(transactions).where(whereClause),
+    db.select({ totalAmount: sum(transactions.amount) }).from(transactions).where(whereClause),
   ]);
 
   const total = Number(countResult[0].total);
+  const totalAmount = Number(sumResult[0].totalAmount ?? 0);
 
   // Fetch child counts for any group rows on this page
   const groupIds = data.filter((tx) => tx.isGroup).map((tx) => tx.id);
@@ -160,6 +162,7 @@ export async function GET(request: Request) {
   return Response.json({
     data: dataWithCounts,
     total,
+    totalAmount,
     page,
     totalPages: Math.ceil(total / limit),
     limit,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,6 +23,11 @@ const Home = () => {
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [totalAmount, setTotalAmount] = useState(0);
+  const [showTotalsRow, setShowTotalsRow] = useState(() => {
+    if (typeof window === "undefined") return true;
+    const stored = localStorage.getItem("showTotalsRow");
+    return stored === null ? true : stored === "true";
+  });
   const [textFilters, setTextFilters] = useState<TextFilters>(EMPTY_TEXT_FILTERS);
   const [debouncedTextFilters, setDebouncedTextFilters] = useState<TextFilters>(EMPTY_TEXT_FILTERS);
   const textFiltersRef = useRef<TextFilters>(EMPTY_TEXT_FILTERS);
@@ -520,7 +525,7 @@ const Home = () => {
               New
             </button>
 
-            <SettingsDrawer />
+            <SettingsDrawer showTotalsRow={showTotalsRow} onToggleTotalsRow={(val) => { localStorage.setItem("showTotalsRow", String(val)); setShowTotalsRow(val); }} />
           </div>
         </header>
 
@@ -570,6 +575,7 @@ const Home = () => {
             textFilters={textFilters}
             onTextFilterChange={handleTextFilterChange}
             totalAmount={totalAmount}
+            showTotalsRow={showTotalsRow}
           />
         </div>
         <div className="shrink-0">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ const Home = () => {
   const [totalPages, setTotalPages] = useState(1);
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [totalAmount, setTotalAmount] = useState(0);
   const [textFilters, setTextFilters] = useState<TextFilters>(EMPTY_TEXT_FILTERS);
   const [debouncedTextFilters, setDebouncedTextFilters] = useState<TextFilters>(EMPTY_TEXT_FILTERS);
   const textFiltersRef = useRef<TextFilters>(EMPTY_TEXT_FILTERS);
@@ -85,6 +86,7 @@ const Home = () => {
         const json: PaginatedResponse = await res.json();
         setPageRows(json.data);
         setTotal(json.total);
+        setTotalAmount(json.totalAmount);
         setTotalPages(json.totalPages);
         setCurrentPage(json.page);
       } finally {
@@ -201,6 +203,17 @@ const Home = () => {
     id: string,
     updates: Partial<Transaction>,
   ) => {
+    if (updates.amount !== undefined) {
+      const existing =
+        pageRows.find((tx) => tx.id === id) ??
+        (pinnedRow?.id === id ? pinnedRow : null) ??
+        Object.values(childRows).flat().find((tx) => tx.id === id) ??
+        null;
+      if (existing) {
+        setTotalAmount((prev) => prev + (updates.amount! - existing.amount));
+      }
+    }
+
     setPageRows((prev) =>
       prev.map((tx) => (tx.id === id ? { ...tx, ...updates } : tx)),
     );
@@ -556,6 +569,7 @@ const Home = () => {
             onFilterChange={handleFilterChange}
             textFilters={textFilters}
             onTextFilterChange={handleTextFilterChange}
+            totalAmount={totalAmount}
           />
         </div>
         <div className="shrink-0">

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -8,7 +8,12 @@ import { Settings } from "lucide-react";
 
 type Theme = "light" | "dark" | "system";
 
-export default function SettingsDrawer() {
+interface SettingsDrawerProps {
+  showTotalsRow: boolean;
+  onToggleTotalsRow: (val: boolean) => void;
+}
+
+export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: SettingsDrawerProps) {
   const { data: session } = authClient.useSession();
   const router = useRouter();
   const [theme, setTheme] = useState<Theme>(() => {
@@ -67,12 +72,20 @@ export default function SettingsDrawer() {
                 </p>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-[13px] font-medium text-gray-600 dark:text-gray-400">Name</span>
-                    <span className="text-[13px] text-gray-900 dark:text-foreground">{user?.name ?? "—"}</span>
+                    <span className="text-[13px] font-medium text-gray-600 dark:text-gray-400">
+                      Name
+                    </span>
+                    <span className="text-[13px] text-gray-900 dark:text-foreground">
+                      {user?.name ?? "—"}
+                    </span>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-[13px] font-medium text-gray-600 dark:text-gray-400">Email</span>
-                    <span className="text-[13px] text-gray-900 dark:text-foreground">{user?.email ?? "—"}</span>
+                    <span className="text-[13px] font-medium text-gray-600 dark:text-gray-400">
+                      Email
+                    </span>
+                    <span className="text-[13px] text-gray-900 dark:text-foreground">
+                      {user?.email ?? "—"}
+                    </span>
                   </div>
                 </div>
               </div>
@@ -82,20 +95,44 @@ export default function SettingsDrawer() {
                 <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
                   Appearance
                 </p>
-                <div className="inline-flex bg-gray-100 dark:bg-[#1b1b1b] rounded-lg p-0.5 gap-0.5">
-                  {(["light", "dark", "system"] as Theme[]).map((option) => (
+                <div className="space-y-4">
+                  <div className="flex justify-between items-center">
+                    <span className="text-[13px] font-medium text-gray-600 dark:text-gray-400">
+                      Show Total Amount
+                    </span>
                     <button
-                      key={option}
-                      onClick={() => handleThemeChange(option)}
-                      className={`px-3 py-1.5 text-[13px] font-medium rounded-md capitalize transition-all ${
-                        theme === option
-                          ? "bg-white dark:bg-[#424242] text-gray-900 dark:text-foreground shadow-sm"
-                          : "text-gray-600 dark:text-gray-400"
-                      }`}
+                      role="switch"
+                      aria-checked={showTotalsRow}
+                      onClick={() => onToggleTotalsRow(!showTotalsRow)}
+                      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors ${showTotalsRow ? "bg-gray-900 dark:bg-gray-100" : "bg-gray-200 dark:bg-gray-700"}`}
                     >
-                      {option}
+                      <span
+                        className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white dark:bg-gray-900 shadow-sm transition-transform mt-0.5 ${showTotalsRow ? "translate-x-4.5" : "translate-x-0.5"}`}
+                      />
                     </button>
-                  ))}
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <span className="text-[13px] font-medium text-gray-600 dark:text-gray-400">
+                      Display
+                    </span>
+                    <div className="inline-flex bg-gray-100 dark:bg-neutral-800 rounded-lg p-0.5 gap-0.5">
+                      {(["light", "dark", "system"] as Theme[]).map(
+                        (option) => (
+                          <button
+                            key={option}
+                            onClick={() => handleThemeChange(option)}
+                            className={`px-3 py-1.5 text-[13px] font-medium rounded-md capitalize transition-all ${
+                              theme === option
+                                ? "bg-white dark:bg-[#424242] text-gray-900 dark:text-foreground shadow-sm"
+                                : "text-gray-600 dark:text-gray-400"
+                            }`}
+                          >
+                            {option}
+                          </button>
+                        ),
+                      )}
+                    </div>
+                  </div>
                 </div>
               </div>
 

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -59,6 +59,7 @@ interface TransactionTableProps {
     col: "description" | "dateFrom" | "dateTo" | "amountMin" | "amountMax",
     value: string,
   ) => void;
+  totalAmount: number;
 }
 
 const localToday = () => {
@@ -105,6 +106,7 @@ const TransactionTable = ({
   onFilterChange,
   textFilters,
   onTextFilterChange,
+  totalAmount,
 }: TransactionTableProps) => {
   const [newTransaction, setNewTransaction] = useState<Partial<Transaction>>({
     date: localToday(),
@@ -569,6 +571,16 @@ const TransactionTable = ({
         className="overflow-x-auto overflow-y-auto flex-1 min-h-0"
       >
         <table className="w-full text-left border-collapse">
+          <colgroup>
+            <col className="w-8" />
+            <col className="w-32" />
+            <col />
+            <col className="w-40" />
+            <col className="w-32" />
+            <col className="w-32" />
+            <col className="w-40" />
+            <col className="w-16" />
+          </colgroup>
           {/* Header */}
           <thead className="sticky top-0 bg-white dark:bg-[#131314] z-2">
             <tr>
@@ -734,6 +746,28 @@ const TransactionTable = ({
             </tr>
           </thead>
           <tbody>
+            {/* Totals Row */}
+            <tr className="border-b border-gray-100 dark:border-gray-800">
+              <td colSpan={4} />
+              <td className="h-9 px-4 text-[13px] font-medium whitespace-nowrap text-right">
+                {(() => {
+                  const isPositive = totalAmount >= 0;
+                  const formatted = new Intl.NumberFormat("en-US", {
+                    style: "currency",
+                    currency: "USD",
+                    minimumFractionDigits: 2,
+                  }).format(Math.abs(totalAmount));
+                  return (
+                    <span className={isPositive ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"}>
+                      {isPositive ? "+" : "-"}{formatted}
+                    </span>
+                  );
+                })()}
+              </td>
+              <td />
+              <td />
+              <td />
+            </tr>
             {/* Add Transaction Row */}
             {showAddRow && (
               <tr className="bg-gray-50/50 dark:bg-[#1b1b1b]/50 border-b border-gray-200 dark:border-gray-700">

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -60,6 +60,7 @@ interface TransactionTableProps {
     value: string,
   ) => void;
   totalAmount: number;
+  showTotalsRow: boolean;
 }
 
 const localToday = () => {
@@ -107,6 +108,7 @@ const TransactionTable = ({
   textFilters,
   onTextFilterChange,
   totalAmount,
+  showTotalsRow,
 }: TransactionTableProps) => {
   const [newTransaction, setNewTransaction] = useState<Partial<Transaction>>({
     date: localToday(),
@@ -747,7 +749,7 @@ const TransactionTable = ({
           </thead>
           <tbody>
             {/* Totals Row */}
-            <tr className="border-b border-gray-100 dark:border-gray-800">
+            {showTotalsRow && <tr className="border-b border-gray-100 dark:border-gray-800">
               <td colSpan={4} />
               <td className="h-9 px-4 text-[13px] font-medium whitespace-nowrap text-right">
                 {(() => {
@@ -767,7 +769,7 @@ const TransactionTable = ({
               <td />
               <td />
               <td />
-            </tr>
+            </tr>}
             {/* Add Transaction Row */}
             {showAddRow && (
               <tr className="bg-gray-50/50 dark:bg-[#1b1b1b]/50 border-b border-gray-200 dark:border-gray-700">

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -30,6 +30,7 @@ export interface SortConfig {
 export interface PaginatedResponse {
     data: Transaction[];
     total: number;
+    totalAmount: number;
     page: number;
     totalPages: number;
     limit: number;


### PR DESCRIPTION
## Summary

Adds a totals row to the transaction table showing the sum of all transactions matching the current filters.

- **API**: Added `sum(transactions.amount)` to `GET /api/transactions`, returned as `totalAmount` alongside existing pagination fields
- **Totals row**: Rendered at the top of `<tbody>` in `TransactionTable`, formatted as USD currency (green for positive, red for negative)
- **Optimistic updates**: Editing a transaction's amount inline immediately updates `totalAmount` without waiting for a refetch
- **Toggle**: "Show Total Amount" switch added to the Settings drawer, persisted to `localStorage`
- **Column widths**: Added `<colgroup>` to stabilize column widths across the table

## Files Changed

- `app/api/transactions/route.ts` — added `sum` query, returned `totalAmount` in response
- `types/transaction.ts` — added `totalAmount` to `PaginatedResponse`
- `app/page.tsx` — `totalAmount` + `showTotalsRow` state, optimistic delta on amount edit
- `components/TransactionTable.tsx` — totals row, `<colgroup>`, new props
- `components/SettingsDrawer.tsx` — toggle for totals row visibility, reorganized Appearance section
