### PR TITLE
23 receipt tracking

### DIFF
--- a/app/api/drive/callback/route.ts
+++ b/app/api/drive/callback/route.ts
@@ -1,0 +1,83 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { driveTokens } from "@/lib/db/schema";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+  const state = searchParams.get("state");
+  const error = searchParams.get("error");
+
+  if (error) {
+    return NextResponse.redirect(
+      `${process.env.BETTER_AUTH_URL}/?driveError=${error}`,
+    );
+  }
+
+  // Verify CSRF state
+  const storedState = request.cookies.get("drive_oauth_state")?.value;
+  if (!state || !storedState || state !== storedState) {
+    return NextResponse.json({ error: "Invalid state" }, { status: 400 });
+  }
+
+  if (!code) {
+    return NextResponse.json({ error: "Missing code" }, { status: 400 });
+  }
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Exchange code for tokens
+  const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: process.env.GOOGLE_CLIENT_ID!,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET!,
+      redirect_uri: `${process.env.BETTER_AUTH_URL}/api/drive/callback`,
+      grant_type: "authorization_code",
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    return NextResponse.json(
+      { error: "Failed to exchange token" },
+      { status: 500 },
+    );
+  }
+
+  const tokenData = await tokenRes.json();
+
+  // Upsert drive token for this user
+  await db
+    .insert(driveTokens)
+    .values({
+      id: crypto.randomUUID(),
+      userId: session.user.id,
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token ?? null,
+      accessTokenExpiresAt: tokenData.expires_in
+        ? new Date(Date.now() + tokenData.expires_in * 1000)
+        : null,
+      scope: tokenData.scope ?? null,
+    })
+    .onConflictDoUpdate({
+      target: driveTokens.userId,
+      set: {
+        accessToken: tokenData.access_token,
+        refreshToken: tokenData.refresh_token ?? null,
+        accessTokenExpiresAt: tokenData.expires_in
+          ? new Date(Date.now() + tokenData.expires_in * 1000)
+          : null,
+        scope: tokenData.scope ?? null,
+      },
+    });
+
+  const response = NextResponse.redirect(`${process.env.BETTER_AUTH_URL}/`);
+  response.cookies.delete("drive_oauth_state");
+  return response;
+}

--- a/app/api/drive/connect/route.ts
+++ b/app/api/drive/connect/route.ts
@@ -1,0 +1,37 @@
+import { auth } from "@/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const nonce = crypto.randomUUID();
+
+  const oauthUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  oauthUrl.searchParams.set("client_id", process.env.GOOGLE_CLIENT_ID!);
+  oauthUrl.searchParams.set(
+    "redirect_uri",
+    `${process.env.BETTER_AUTH_URL}/api/drive/callback`,
+  );
+  oauthUrl.searchParams.set("response_type", "code");
+  oauthUrl.searchParams.set(
+    "scope",
+    "https://www.googleapis.com/auth/drive.file",
+  );
+  oauthUrl.searchParams.set("access_type", "offline");
+  oauthUrl.searchParams.set("prompt", "consent");
+  oauthUrl.searchParams.set("state", nonce);
+
+  const response = NextResponse.redirect(oauthUrl.toString());
+  response.cookies.set("drive_oauth_state", nonce, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60 * 10, // 10 minutes
+    path: "/",
+  });
+
+  return response;
+}

--- a/app/api/drive/file/[fileId]/route.ts
+++ b/app/api/drive/file/[fileId]/route.ts
@@ -1,0 +1,35 @@
+import { auth } from "@/lib/auth";
+import { getValidDriveToken } from "@/lib/driveAuth";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ fileId: string }> },
+) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { fileId } = await params;
+  const accessToken = await getValidDriveToken(session.user.id);
+
+  if (!accessToken) {
+    return Response.json(
+      { error: "No Google Drive access. Please reconnect your Google account." },
+      { status: 403 },
+    );
+  }
+
+  const res = await fetch(
+    `https://www.googleapis.com/drive/v3/files/${fileId}?fields=id,name,mimeType,webViewLink`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+
+  if (!res.ok) {
+    const err = await res.json();
+    return Response.json(
+      { error: err.error?.message ?? "Drive API error" },
+      { status: res.status },
+    );
+  }
+
+  return Response.json(await res.json());
+}

--- a/app/api/drive/token/route.ts
+++ b/app/api/drive/token/route.ts
@@ -1,0 +1,17 @@
+import { auth } from "@/lib/auth";
+import { getValidDriveToken } from "@/lib/driveAuth";
+
+export async function GET(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const accessToken = await getValidDriveToken(session.user.id);
+  if (!accessToken) {
+    return Response.json(
+      { error: "No Google Drive access. Please reconnect your Google account." },
+      { status: 403 },
+    );
+  }
+
+  return Response.json({ accessToken });
+}

--- a/app/api/drive/upload/route.ts
+++ b/app/api/drive/upload/route.ts
@@ -1,0 +1,91 @@
+import { auth } from "@/lib/auth";
+import { getValidDriveToken } from "@/lib/driveAuth";
+
+const FOLDER_NAME = "showmethemoney";
+
+async function getOrCreateFolder(accessToken: string): Promise<string> {
+  // Search for an existing folder the app created
+  const searchRes = await fetch(
+    `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(
+      `mimeType='application/vnd.google-apps.folder' and name='${FOLDER_NAME}' and trashed=false`,
+    )}&fields=files(id)`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+
+  if (searchRes.ok) {
+    const { files } = await searchRes.json();
+    if (files?.length > 0) return files[0].id;
+  }
+
+  // Create it if not found
+  const createRes = await fetch(
+    "https://www.googleapis.com/drive/v3/files?fields=id",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: FOLDER_NAME,
+        mimeType: "application/vnd.google-apps.folder",
+      }),
+    },
+  );
+
+  const folder = await createRes.json();
+  return folder.id;
+}
+
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const accessToken = await getValidDriveToken(session.user.id);
+  if (!accessToken) {
+    return Response.json(
+      { error: "No Google Drive access. Please reconnect your Google account." },
+      { status: 403 },
+    );
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file") as File | null;
+  if (!file) return Response.json({ error: "No file provided" }, { status: 400 });
+
+  const folderId = await getOrCreateFolder(accessToken);
+
+  const boundary = "-------314159265358979323846";
+  const metadata = JSON.stringify({ name: file.name, parents: [folderId] });
+  const fileBytes = new Uint8Array(await file.arrayBuffer());
+  const enc = new TextEncoder();
+
+  const body = new Uint8Array([
+    ...enc.encode(`--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n`),
+    ...enc.encode(`--${boundary}\r\nContent-Type: ${file.type || "application/octet-stream"}\r\n\r\n`),
+    ...fileBytes,
+    ...enc.encode(`\r\n--${boundary}--`),
+  ]);
+
+  const res = await fetch(
+    "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,mimeType,webViewLink",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": `multipart/related; boundary=${boundary}`,
+      },
+      body,
+    },
+  );
+
+  if (!res.ok) {
+    const err = await res.json();
+    return Response.json(
+      { error: err.error?.message ?? "Upload failed" },
+      { status: res.status },
+    );
+  }
+
+  return Response.json(await res.json(), { status: 201 });
+}

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -190,6 +190,7 @@ function toInsertValues(tx: Record<string, unknown>, userId: string) {
     createdAt: typeof tx.createdAt === "number" ? tx.createdAt : Date.now(),
     isGroup: (tx.isGroup as boolean) ?? false,
     parentId: (tx.parentId as string) ?? null,
+    driveFileId: (tx.driveFileId as string) ?? null,
     userId,
   };
 }

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,0 +1,15 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { user } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function DELETE(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  await db.delete(user).where(eq(user.id, session.user.id));
+
+  return Response.json({ success: true });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -179,27 +179,24 @@ const Home = () => {
     newTransaction: Omit<Transaction, "id" | "createdAt">,
   ) => {
     const now = Date.now();
-    const transaction: Transaction = {
-      ...newTransaction,
-      id: crypto.randomUUID(),
-      createdAt: now,
-    };
 
     fetch("/api/transactions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(transaction),
-    }).then(() => {
-      addMetadata(newTransaction);
-      setPinnedRow(transaction);
-      setCurrentPage(1);
-      // If already on page 1, currentPage state won't change so trigger manually
-      fetchPage({
-        page: 1,
-        sortBy: sortConfig?.key ?? null,
-        sortDir: sortConfig?.direction ?? null,
+      body: JSON.stringify({ ...newTransaction, createdAt: now }),
+    })
+      .then((res) => res.json())
+      .then((created: Transaction) => {
+        addMetadata(newTransaction);
+        setPinnedRow(created);
+        setCurrentPage(1);
+        // If already on page 1, currentPage state won't change so trigger manually
+        fetchPage({
+          page: 1,
+          sortBy: sortConfig?.key ?? null,
+          sortDir: sortConfig?.direction ?? null,
+        });
       });
-    });
 
     setShowAddRow(false);
   };

--- a/components/CSVImportModal.tsx
+++ b/components/CSVImportModal.tsx
@@ -186,6 +186,7 @@ const CSVImportModal = ({ isOpen, onClose, onImport }: CSVImportModalProps) => {
           source: null,
           isGroup: false,
           parentId: null,
+          driveFileId: null,
         }));
       onImport(newTransactions);
       onClose();
@@ -233,6 +234,7 @@ const CSVImportModal = ({ isOpen, onClose, onImport }: CSVImportModalProps) => {
         source: null,
         isGroup: false,
         parentId: null,
+        driveFileId: null,
       };
     });
     onImport(newTransactions);

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Drawer } from "@base-ui/react/drawer";
 import { authClient } from "@/lib/auth-client";
-import { Settings } from "lucide-react";
+import { Settings, HardDrive, Check, Loader } from "lucide-react";
 
 type Theme = "light" | "dark" | "system";
 
@@ -42,6 +42,23 @@ export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: Set
   }
 
   const user = session?.user;
+
+  const [driveConnected, setDriveConnected] = useState<boolean | null>(null);
+  const [driveConnecting, setDriveConnecting] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/drive/token")
+      .then((r) => setDriveConnected(r.ok))
+      .catch(() => setDriveConnected(false));
+  }, []);
+
+  async function handleConnectDrive() {
+    setDriveConnecting(true);
+    await authClient.signIn.social({
+      provider: "google",
+      callbackURL: window.location.href,
+    });
+  }
 
   function handleLogout() {
     authClient.signOut({
@@ -133,6 +150,37 @@ export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: Set
                       )}
                     </div>
                   </div>
+                </div>
+              </div>
+
+              {/* Integrations section */}
+              <div className="border-t border-gray-100 dark:border-gray-800 pt-6 mb-6">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+                  Integrations
+                </p>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <HardDrive className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                    <span className="text-[13px] font-medium text-gray-600 dark:text-gray-400">
+                      Google Drive
+                    </span>
+                  </div>
+                  {driveConnected === null ? (
+                    <Loader className="w-3.5 h-3.5 text-gray-400 animate-spin" />
+                  ) : driveConnected ? (
+                    <span className="flex items-center gap-1 text-[12px] text-emerald-600 dark:text-emerald-400">
+                      <Check className="w-3.5 h-3.5" />
+                      Connected
+                    </span>
+                  ) : (
+                    <button
+                      onClick={handleConnectDrive}
+                      disabled={driveConnecting}
+                      className="text-[12px] font-medium text-blue-600 dark:text-blue-400 hover:underline disabled:opacity-50"
+                    >
+                      {driveConnecting ? "Connecting…" : "Connect"}
+                    </button>
+                  )}
                 </div>
               </div>
 

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Drawer } from "@base-ui/react/drawer";
 import { authClient } from "@/lib/auth-client";
-import { Settings, HardDrive, Check, Loader } from "lucide-react";
+import { Settings, HardDrive, Loader } from "lucide-react";
 
 type Theme = "light" | "dark" | "system";
 
@@ -45,6 +45,8 @@ export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: Set
 
   const [driveConnected, setDriveConnected] = useState<boolean | null>(null);
   const [driveConnecting, setDriveConnecting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     fetch("/api/drive/token")
@@ -52,12 +54,20 @@ export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: Set
       .catch(() => setDriveConnected(false));
   }, []);
 
-  async function handleConnectDrive() {
+  function handleConnectDrive() {
     setDriveConnecting(true);
-    await authClient.signIn.social({
-      provider: "google",
-      callbackURL: window.location.href,
-    });
+    window.location.href = "/api/drive/connect";
+  }
+
+  async function handleDeleteAccount() {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setDeleting(true);
+    await fetch("/api/user", { method: "DELETE" });
+    await authClient.signOut();
+    router.push("/sign-in");
   }
 
   function handleLogout() {
@@ -87,7 +97,7 @@ export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: Set
                 <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
                   Account
                 </p>
-                <div className="space-y-3">
+                <div className="flex flex-col gap-3">
                   <div className="flex items-center justify-between">
                     <span className="text-[13px] font-medium text-gray-600 dark:text-gray-400">
                       Name
@@ -103,6 +113,38 @@ export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: Set
                     <span className="text-[13px] text-gray-900 dark:text-foreground">
                       {user?.email ?? "—"}
                     </span>
+                  </div>
+                  <div className="pt-1 self-end">
+                    {confirmDelete ? (
+                      <div className="rounded-md border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-950 p-3 space-y-2">
+                        <p className="text-[12px] text-rose-700 dark:text-rose-300">
+                          This will permanently delete your account and all your
+                          data. This cannot be undone.
+                        </p>
+                        <div className="flex items-center gap-2">
+                          <button
+                            onClick={handleDeleteAccount}
+                            disabled={deleting}
+                            className="flex h-7 items-center justify-center rounded bg-rose-600 dark:bg-rose-700 px-3 text-[12px] font-medium text-white hover:bg-rose-700 dark:hover:bg-rose-600 disabled:opacity-50"
+                          >
+                            {deleting ? "Deleting…" : "Yes, delete my account"}
+                          </button>
+                          <button
+                            onClick={() => setConfirmDelete(false)}
+                            className="text-[12px] text-gray-500 dark:text-gray-400 hover:underline"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmDelete(true)}
+                        className="hover:text-rose-600 dark:hover:text-rose-400 px-3 py-1.5 text-[13px] font-medium rounded-md capitalize transition-all bg-white dark:bg-[#424242] text-gray-900 dark:text-foreground shadow-sm"
+                      >
+                        Delete account
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>
@@ -168,15 +210,14 @@ export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: Set
                   {driveConnected === null ? (
                     <Loader className="w-3.5 h-3.5 text-gray-400 animate-spin" />
                   ) : driveConnected ? (
-                    <span className="flex items-center gap-1 text-[12px] text-emerald-600 dark:text-emerald-400">
-                      <Check className="w-3.5 h-3.5" />
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[12px] font-medium tracking-wide bg-emerald-50 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400">
                       Connected
                     </span>
                   ) : (
                     <button
                       onClick={handleConnectDrive}
                       disabled={driveConnecting}
-                      className="text-[12px] font-medium text-blue-600 dark:text-blue-400 hover:underline disabled:opacity-50"
+                      className="inline-flex items-center text-[12px] font-medium text-gray-900 dark:text-foreground px-2 py-0.5 rounded border border-transparent hover:border-gray-900 dark:hover:border-foreground disabled:opacity-50"
                     >
                       {driveConnecting ? "Connecting…" : "Connect"}
                     </button>

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -6,8 +6,10 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  FileText,
   Layers,
   ListFilter,
+  Paperclip,
   Trash,
   Unlink,
   X,
@@ -17,6 +19,77 @@ import StatusBadge from "./StatusBadge";
 import InputAutocomplete from "./InputAutocomplete";
 import BulkActions from "./BulkActions";
 import { computeGroupFields } from "@/lib/groupUtils";
+
+function DriveFileCell({
+  fileId,
+  onUnlink,
+}: {
+  fileId: string;
+  onUnlink: () => void;
+}) {
+  const [file, setFile] = useState<{
+    name: string;
+    webViewLink: string;
+  } | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch(`/api/drive/file/${fileId}`)
+      .then((r) => {
+        if (!r.ok) {
+          setError(true);
+          return null;
+        }
+        return r.json();
+      })
+      .then((data) => {
+        if (data?.name)
+          setFile({ name: data.name, webViewLink: data.webViewLink });
+        else if (data) setError(true);
+      })
+      .catch(() => setError(true));
+  }, [fileId]);
+
+  if (error) {
+    return (
+      <span title="Could not load file">
+        <FileText className="w-3.5 h-3.5 text-red-800" />
+      </span>
+    );
+  }
+
+  if (!file) {
+    return (
+      <FileText className="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 animate-pulse" />
+    );
+  }
+  return (
+    <div className="flex relative">
+      <a
+        href={file.webViewLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={file.name}
+        onClick={(e) => e.stopPropagation()}
+        className="p-0.5"
+      >
+        <FileText className="w-3.5 h-3.5 text-blue-500 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors" />
+      </a>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onUnlink();
+        }}
+        className="absolute -top-1.5 -right-2.5 w-3 h-3 flex items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 hover:bg-rose-100 dark:hover:bg-rose-900 hover:text-rose-600 dark:hover:text-rose-400 opacity-0 group-hover:opacity-100 transition-all"
+        aria-label="Remove file"
+        title="Remove file"
+      >
+        <X className="w-2 h-2" />
+      </button>
+    </div>
+  );
+}
+
 
 interface TransactionTableProps {
   transactions: Transaction[];
@@ -119,7 +192,59 @@ const TransactionTable = ({
     source: null,
     isGroup: false,
     parentId: null,
+    driveFileId: null,
   });
+
+  const attachingTxIdRef = useRef<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadingIds, setUploadingIds] = useState<Set<string>>(new Set());
+  const [driveConnected, setDriveConnected] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    fetch("/api/drive/token").then((r) => setDriveConnected(r.ok));
+  }, []);
+
+  const handleAttach = (txId: string) => {
+    if (!driveConnected) {
+      alert("Google Drive is not connected. Go to Settings → Integrations → Connect.");
+      return;
+    }
+    attachingTxIdRef.current = txId;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    const txId = attachingTxIdRef.current;
+    e.target.value = "";
+    if (!file || !txId) return;
+
+    setUploadingIds((prev) => new Set([...prev, txId]));
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await fetch("/api/drive/upload", {
+        method: "POST",
+        body: formData,
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        alert(err.error ?? "Upload failed");
+        return;
+      }
+      const { id } = await res.json();
+      onUpdate(txId, { driveFileId: id });
+    } catch {
+      alert("Upload failed");
+    } finally {
+      setUploadingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(txId);
+        return next;
+      });
+      attachingTxIdRef.current = null;
+    }
+  };
   const pendingFocusIdRef = useRef<string | null>(null);
   const [editingCell, setEditingCell] = useState<{
     id: string;
@@ -363,7 +488,6 @@ const TransactionTable = ({
     );
   };
 
-
   const selectableIds = useMemo(
     () => transactions.filter((tx) => !tx.isGroup).map((tx) => tx.id),
     [transactions],
@@ -473,6 +597,7 @@ const TransactionTable = ({
       source: newTransaction.source ?? null,
       isGroup: false,
       parentId: null,
+      driveFileId: null,
     });
     setNewTransaction({
       date: localToday(),
@@ -483,6 +608,7 @@ const TransactionTable = ({
       source: null,
       isGroup: false,
       parentId: null,
+      driveFileId: null,
     });
   };
 
@@ -581,6 +707,7 @@ const TransactionTable = ({
             <col className="w-32" />
             <col className="w-32" />
             <col className="w-40" />
+            <col className="w-32" />
             <col className="w-16" />
           </colgroup>
           {/* Header */}
@@ -744,32 +871,43 @@ const TransactionTable = ({
                 {openFilterCol === "source" &&
                   renderFilterDropdown("source", allSources, true)}
               </th>
+              <th className={`${thClass} w-32`}>File</th>
               <th className={`${thClass} w-16`} />
             </tr>
           </thead>
           <tbody>
             {/* Totals Row */}
-            {showTotalsRow && <tr className="border-b border-gray-100 dark:border-gray-800">
-              <td colSpan={4} />
-              <td className="h-9 px-4 text-[13px] font-medium whitespace-nowrap text-right">
-                {(() => {
-                  const isPositive = totalAmount >= 0;
-                  const formatted = new Intl.NumberFormat("en-US", {
-                    style: "currency",
-                    currency: "USD",
-                    minimumFractionDigits: 2,
-                  }).format(Math.abs(totalAmount));
-                  return (
-                    <span className={isPositive ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"}>
-                      {isPositive ? "+" : "-"}{formatted}
-                    </span>
-                  );
-                })()}
-              </td>
-              <td />
-              <td />
-              <td />
-            </tr>}
+            {showTotalsRow && (
+              <tr className="border-b border-gray-100 dark:border-gray-800">
+                <td colSpan={4} />
+                <td className="h-9 px-4 text-[13px] font-medium whitespace-nowrap text-right">
+                  {(() => {
+                    const isPositive = totalAmount >= 0;
+                    const formatted = new Intl.NumberFormat("en-US", {
+                      style: "currency",
+                      currency: "USD",
+                      minimumFractionDigits: 2,
+                    }).format(Math.abs(totalAmount));
+                    return (
+                      <span
+                        className={
+                          isPositive
+                            ? "text-emerald-600 dark:text-emerald-400"
+                            : "text-rose-600 dark:text-rose-400"
+                        }
+                      >
+                        {isPositive ? "+" : "-"}
+                        {formatted}
+                      </span>
+                    );
+                  })()}
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+            )}
             {/* Add Transaction Row */}
             {showAddRow && (
               <tr className="bg-gray-50/50 dark:bg-[#1b1b1b]/50 border-b border-gray-200 dark:border-gray-700">
@@ -869,6 +1007,8 @@ const TransactionTable = ({
                     positionerZIndex={50}
                   />
                 </td>
+                {/* File — not available on new row */}
+                <td className="h-9 px-3" />
                 {/* Extra */}
                 <td className="py-1.5 px-3 text-right">
                   <div className="flex items-center justify-end gap-2">
@@ -898,7 +1038,7 @@ const TransactionTable = ({
             {transactions.length === 0 ? (
               <tr>
                 <td
-                  colSpan={8}
+                  colSpan={9}
                   className="py-8 text-center text-[13px] text-gray-400 dark:text-gray-500"
                 >
                   No transactions found.
@@ -1010,7 +1150,9 @@ const TransactionTable = ({
                           />
                         ) : (
                           <span className="flex items-center gap-1.5 py-px min-w-0">
-                            <span className="uppercase truncate">{tx.description}</span>
+                            <span className="uppercase truncate">
+                              {tx.description}
+                            </span>
                             {tx.isGroup && tx.childCount !== undefined && (
                               <span className="text-gray-400 dark:text-gray-500 text-[11px] font-normal">
                                 · {tx.childCount}{" "}
@@ -1158,6 +1300,30 @@ const TransactionTable = ({
                             {display.source ?? ""}
                           </span>
                         )}
+                      </td>
+
+                      {/* File */}
+                      <td className={`${tdClass} flex items-center`}>
+                        {!tx.isGroup &&
+                          (uploadingIds.has(tx.id) ? (
+                            <FileText className="w-3.5 h-3.5 text-gray-500 dark:text-gray-400 animate-pulse" />
+                          ) : tx.driveFileId ? (
+                            <DriveFileCell
+                              fileId={tx.driveFileId}
+                              onUnlink={() =>
+                                onUpdate(tx.id, { driveFileId: null })
+                              }
+                            />
+                          ) : (
+                            <button
+                              onClick={() => handleAttach(tx.id)}
+                              className="p-0.5 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-400 opacity-0 group-hover:opacity-100 transition-all focus:opacity-100"
+                              aria-label="Upload file to Drive"
+                              title="Upload file to Google Drive"
+                            >
+                              <Paperclip className="w-3.5 h-3.5" />
+                            </button>
+                          ))}
                       </td>
 
                       {/* Controls */}
@@ -1421,6 +1587,29 @@ const TransactionTable = ({
                             )}
                           </td>
 
+                          {/* File */}
+                          <td className={`${tdClass} flex items-center`}>
+                            {uploadingIds.has(child.id) ? (
+                              <FileText className="w-3.5 h-3.5 text-gray-500 dark:text-gray-400 animate-pulse" />
+                            ) : child.driveFileId ? (
+                              <DriveFileCell
+                                fileId={child.driveFileId}
+                                onUnlink={() =>
+                                  onUpdate(child.id, { driveFileId: null })
+                                }
+                              />
+                            ) : (
+                              <button
+                                onClick={() => handleAttach(child.id)}
+                                className="p-0.5 text-gray-300 hover:text-gray-600 dark:text-gray-600 dark:hover:text-gray-400 opacity-0 group-hover:opacity-100 transition-all focus:opacity-100"
+                                aria-label="Upload file to Drive"
+                                title="Upload file to Google Drive"
+                              >
+                                <Paperclip className="w-3.5 h-3.5" />
+                              </button>
+                            )}
+                          </td>
+
                           {/* Unlink from group */}
                           <td className={`${tdClass} text-right`}>
                             <button
@@ -1441,6 +1630,12 @@ const TransactionTable = ({
           </tbody>
         </table>
       </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        className="hidden"
+        onChange={handleFileSelected}
+      />
     </div>
   );
 };

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -15,9 +15,6 @@ export const auth = betterAuth({
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-      scope: ["https://www.googleapis.com/auth/drive.file"],
-      accessType: "offline",
-      prompt: "consent",
     },
   },
 });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -15,6 +15,9 @@ export const auth = betterAuth({
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      scope: ["https://www.googleapis.com/auth/drive.file"],
+      accessType: "offline",
+      prompt: "consent",
     },
   },
 });

--- a/lib/db/migrations/0001_fearless_kronos.sql
+++ b/lib/db/migrations/0001_fearless_kronos.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "drive_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"access_token" text NOT NULL,
+	"refresh_token" text,
+	"access_token_expires_at" timestamp,
+	"scope" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "drive_tokens_user_id_unique" UNIQUE("user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "drive_tokens" ADD CONSTRAINT "drive_tokens_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/lib/db/migrations/meta/0001_snapshot.json
+++ b/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,600 @@
+{
+  "id": "ff7dd868-6e77-46ab-b4f5-67c534aab283",
+  "prevId": "012ddb8d-0641-43a0-ae18-2507808dc819",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_tokens": {
+      "name": "drive_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "drive_tokens_user_id_user_id_fk": {
+          "name": "drive_tokens_user_id_user_id_fk",
+          "tableFrom": "drive_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_tokens_user_id_unique": {
+          "name": "drive_tokens_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_file_id": {
+          "name": "drive_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_userId_parentId_createdAt_idx": {
+          "name": "transactions_userId_parentId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_user_id_fk": {
+          "name": "transactions_user_id_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_parent_id_transactions_id_fk": {
+          "name": "transactions_parent_id_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776049731518,
       "tag": "0000_daffy_korvac",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776465872650,
+      "tag": "0001_fearless_kronos",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -90,6 +90,7 @@ export const userRelations = relations(user, ({ many }) => ({
   sessions: many(session),
   accounts: many(account),
   transactions: many(transactions),
+  driveTokens: many(driveTokens),
 }));
 
 export const sessionRelations = relations(session, ({ one }) => ({
@@ -152,6 +153,30 @@ export const transactionRelations = relations(transactions, ({ one, many }) => (
   }),
   children: many(transactions, {
     relationName: "parent_child",
+  }),
+}));
+
+export const driveTokens = pgTable("drive_tokens", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .unique()
+    .references(() => user.id, { onDelete: "cascade" }),
+  accessToken: text("access_token").notNull(),
+  refreshToken: text("refresh_token"),
+  accessTokenExpiresAt: timestamp("access_token_expires_at"),
+  scope: text("scope"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => new Date())
+    .notNull(),
+});
+
+export const driveTokenRelations = relations(driveTokens, ({ one }) => ({
+  user: one(user, {
+    fields: [driveTokens.userId],
+    references: [user.id],
   }),
 }));
 

--- a/lib/driveAuth.ts
+++ b/lib/driveAuth.ts
@@ -1,27 +1,26 @@
 import { db } from "@/lib/db";
-import { account } from "@/lib/db/schema";
-import { and, eq } from "drizzle-orm";
+import { driveTokens } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
 
 /**
- * Returns a valid Google access token for the given user, refreshing it if expired.
- * Returns null if the user has no Google account or no refresh token available.
+ * Returns a valid Google Drive access token for the given user, refreshing it if expired.
+ * Returns null if the user has not connected Google Drive.
  */
 export async function getValidDriveToken(userId: string): Promise<string | null> {
-  const [googleAccount] = await db
+  const [record] = await db
     .select()
-    .from(account)
-    .where(and(eq(account.userId, userId), eq(account.providerId, "google")));
+    .from(driveTokens)
+    .where(eq(driveTokens.userId, userId));
 
-  if (!googleAccount?.accessToken) return null;
-  if (!googleAccount.scope?.includes("drive.file")) return null;
+  if (!record?.accessToken) return null;
 
-  const isExpired = googleAccount.accessTokenExpiresAt
-    ? googleAccount.accessTokenExpiresAt < new Date()
+  const isExpired = record.accessTokenExpiresAt
+    ? record.accessTokenExpiresAt < new Date()
     : false;
 
-  if (!isExpired) return googleAccount.accessToken;
+  if (!isExpired) return record.accessToken;
 
-  if (!googleAccount.refreshToken) return null;
+  if (!record.refreshToken) return null;
 
   const res = await fetch("https://oauth2.googleapis.com/token", {
     method: "POST",
@@ -29,7 +28,7 @@ export async function getValidDriveToken(userId: string): Promise<string | null>
     body: new URLSearchParams({
       client_id: process.env.GOOGLE_CLIENT_ID!,
       client_secret: process.env.GOOGLE_CLIENT_SECRET!,
-      refresh_token: googleAccount.refreshToken,
+      refresh_token: record.refreshToken,
       grant_type: "refresh_token",
     }),
   });
@@ -39,12 +38,12 @@ export async function getValidDriveToken(userId: string): Promise<string | null>
   const data = await res.json();
 
   await db
-    .update(account)
+    .update(driveTokens)
     .set({
       accessToken: data.access_token,
       accessTokenExpiresAt: new Date(Date.now() + data.expires_in * 1000),
     })
-    .where(eq(account.id, googleAccount.id));
+    .where(eq(driveTokens.userId, userId));
 
   return data.access_token;
 }

--- a/lib/driveAuth.ts
+++ b/lib/driveAuth.ts
@@ -1,0 +1,50 @@
+import { db } from "@/lib/db";
+import { account } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+
+/**
+ * Returns a valid Google access token for the given user, refreshing it if expired.
+ * Returns null if the user has no Google account or no refresh token available.
+ */
+export async function getValidDriveToken(userId: string): Promise<string | null> {
+  const [googleAccount] = await db
+    .select()
+    .from(account)
+    .where(and(eq(account.userId, userId), eq(account.providerId, "google")));
+
+  if (!googleAccount?.accessToken) return null;
+  if (!googleAccount.scope?.includes("drive.file")) return null;
+
+  const isExpired = googleAccount.accessTokenExpiresAt
+    ? googleAccount.accessTokenExpiresAt < new Date()
+    : false;
+
+  if (!isExpired) return googleAccount.accessToken;
+
+  if (!googleAccount.refreshToken) return null;
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: process.env.GOOGLE_CLIENT_ID!,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET!,
+      refresh_token: googleAccount.refreshToken,
+      grant_type: "refresh_token",
+    }),
+  });
+
+  if (!res.ok) return null;
+
+  const data = await res.json();
+
+  await db
+    .update(account)
+    .set({
+      accessToken: data.access_token,
+      accessTokenExpiresAt: new Date(Date.now() + data.expires_in * 1000),
+    })
+    .where(eq(account.id, googleAccount.id));
+
+  return data.access_token;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2726,9 +2726,9 @@
       }
     },
     "node_modules/@types/pg": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.18.0.tgz",
-      "integrity": "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -6988,6 +6988,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -6995,6 +7040,17 @@
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
@@ -7017,6 +7073,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -7649,6 +7716,17 @@
       "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "npx tsx ./scripts/migrate.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,41 @@
+import { drizzle } from "drizzle-orm/neon-http";
+import { neon } from "@neondatabase/serverless";
+import { migrate } from "drizzle-orm/neon-http/migrator";
+import { config } from "dotenv";
+
+config({ path: ".env.local" });
+
+const sql = neon(process.env.DATABASE_URL!);
+const db = drizzle(sql);
+
+const main = async () => {
+  try {
+    // Ensure drizzle's migration tracking table exists and that the initial
+    // migration (0000) is recorded — those tables were created outside of
+    // drizzle-kit so the migrator has no record of them.
+    await sql`CREATE SCHEMA IF NOT EXISTS drizzle`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+        id SERIAL PRIMARY KEY,
+        hash text NOT NULL,
+        created_at bigint
+      )
+    `;
+    await sql`
+      INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
+      SELECT '0000_daffy_korvac', 1776049731518
+      WHERE NOT EXISTS (
+        SELECT 1 FROM drizzle.__drizzle_migrations
+        WHERE hash = '0000_daffy_korvac'
+      )
+    `;
+
+    await migrate(db, { migrationsFolder: "./lib/db/migrations" });
+    console.log("Migration completed");
+  } catch (error) {
+    console.error("Error during migration:", error);
+    process.exit(1);
+  }
+};
+
+main();

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -2,7 +2,7 @@ export type Status = "Completed" | "Refunding" | "Owed";
 
 export const STATUSES: Status[] = ["Completed", "Owed", "Refunding"];
 
-export const UPDATABLE_FIELDS = ["date", "description", "category", "amount", "status", "source", "parentId"] as const;
+export const UPDATABLE_FIELDS = ["date", "description", "category", "amount", "status", "source", "parentId", "driveFileId"] as const;
 
 export type Category = string
 
@@ -19,6 +19,7 @@ export interface Transaction {
     createdAt: number //timestamp since never displayed
     isGroup: boolean
     parentId: string | null
+    driveFileId: string | null
     childCount?: number
 }
 


### PR DESCRIPTION
## Summary

- Added Google Drive OAuth integration — users can connect their Google account from Settings to enable receipt file storage
- New `drive_tokens` table stores per-user access/refresh tokens with automatic token refresh on expiry
- Added delete account flow in Settings with a confirmation step that wipes all user data
- Added migration script (`scripts/migrate.ts`) to bootstrap Drizzle's migration tracking table on databases created outside of drizzle-kit

## API routes added

- `GET /api/drive/connect` — initiates OAuth flow with CSRF state cookie
- `GET /api/drive/callback` — exchanges auth code for tokens, upserts into `drive_tokens`
- `GET /api/drive/token` — returns a valid (auto-refreshed) access token for the session user
- `POST /api/drive/upload` — uploads a file to a per-app folder in the user's Drive
- `GET /api/drive/file/[fileId]` — fetches Drive file metadata by ID
- `DELETE /api/user` — deletes the authenticated user and all associated data

## Database changes

- New `drive_tokens` table (`lib/db/migrations/0001_fearless_kronos.sql`)
- `driveFileId` column added to `transactions` for future receipt linking

## Test plan

- [x] Connect Google Drive from Settings drawer — verify redirect flow and "Connected" badge appears
- [x] Refresh the page after connecting — badge should persist
- [x] Upload a file via `/api/drive/upload` and confirm it appears in Drive under the `showmethemoney` folder
- [x] Delete account — confirm confirmation dialog appears, account is removed, and redirects to sign-in
- [x] Verify existing transactions and auth are unaffected
