### PR TITLE
moved from using inputAutocomplete to regular input

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -233,13 +233,13 @@ const Home = () => {
     id: string,
     updates: Partial<Transaction>,
   ) => {
-    await fetch(`/api/transactions/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(updates),
-    });
+    // Compute parentGroupId before childRows is mutated
+    const parentGroupId =
+      Object.keys(childRows).find((gid) =>
+        childRows[gid].some((tx) => tx.id === id),
+      ) ?? null;
 
-    //sets totalAmount without refetching from the DB
+    // Optimistically update all local state before awaiting the network call
     if (updates.amount !== undefined) {
       const existing =
         pageRows.find((tx) => tx.id === id) ??
@@ -274,11 +274,6 @@ const Home = () => {
       fetchMetadata();
     }
 
-    const parentGroupId =
-      Object.keys(childRows).find((gid) =>
-        childRows[gid].some((tx) => tx.id === id),
-      ) ?? null;
-
     if (parentGroupId) {
       const updatedChildren = childRows[parentGroupId].map((tx) =>
         tx.id === id ? { ...tx, ...updates } : tx,
@@ -305,6 +300,12 @@ const Home = () => {
         body: JSON.stringify(groupUpdates),
       });
     }
+
+    await fetch(`/api/transactions/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(updates),
+    });
   };
 
   const handleDeleteTransaction = async (id: string) => {

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -16,7 +16,6 @@ import {
 } from "lucide-react";
 import { Transaction, SortConfig, Status, STATUSES } from "@/types/transaction";
 import StatusBadge from "./StatusBadge";
-import InputAutocomplete from "./InputAutocomplete";
 import BulkActions from "./BulkActions";
 
 function DriveFileCell({
@@ -965,17 +964,18 @@ const TransactionTable = ({
                 </td>
                 {/* Category */}
                 <td className="h-9 px-3">
-                  <InputAutocomplete
+                  <input
+                    type="text"
+                    placeholder="Category..."
                     value={newTransaction.category ?? ""}
-                    onChange={(val) =>
+                    autoCapitalize="none"
+                    className={addInputClass}
+                    onChange={(e) =>
                       setNewTransaction({
                         ...newTransaction,
-                        category: val.trim() || null,
+                        category: e.target.value || null,
                       })
                     }
-                    suggestions={allCategories}
-                    placeholder="Category..."
-                    positionerZIndex={50}
                   />
                 </td>
                 {/* Amount */}
@@ -1015,17 +1015,18 @@ const TransactionTable = ({
                 </td>
                 {/* Source */}
                 <td className="h-9 px-3">
-                  <InputAutocomplete
+                  <input
+                    type="text"
+                    placeholder="Source..."
                     value={newTransaction.source ?? ""}
-                    onChange={(val) =>
+                    autoCapitalize="none"
+                    className={addInputClass}
+                    onChange={(e) =>
                       setNewTransaction({
                         ...newTransaction,
-                        source: val.trim() || null,
+                        source: e.target.value || null,
                       })
                     }
-                    suggestions={allSources}
-                    placeholder="Source..."
-                    positionerZIndex={50}
                   />
                 </td>
                 {/* File — not available on new row */}
@@ -1193,21 +1194,15 @@ const TransactionTable = ({
                         }
                       >
                         {isEditing(tx.id, "category") ? (
-                          <InputAutocomplete
+                          <input
+                            ref={inputRef as React.RefObject<HTMLInputElement>}
+                            type="text"
                             value={editValue}
-                            onChange={setEditValue}
+                            autoCapitalize="none"
+                            onChange={(e) => setEditValue(e.target.value)}
                             onBlur={commitEdit}
-                            onCancel={() => {
-                              setEditingCell(null);
-                              setEditValue("");
-                            }}
-                            onCommit={(val) => {
-                              onUpdate(tx.id, { category: val.trim() || null });
-                              setEditingCell(null);
-                              setEditValue("");
-                            }}
-                            suggestions={allCategories}
-                            positionerZIndex={50}
+                            onKeyDown={handleKeyDown}
+                            className={editInputClass}
                           />
                         ) : (
                           <span className="block py-px">
@@ -1293,21 +1288,15 @@ const TransactionTable = ({
                         }
                       >
                         {isEditing(tx.id, "source") ? (
-                          <InputAutocomplete
+                          <input
+                            ref={inputRef as React.RefObject<HTMLInputElement>}
+                            type="text"
                             value={editValue}
-                            onChange={setEditValue}
+                            autoCapitalize="none"
+                            onChange={(e) => setEditValue(e.target.value)}
                             onBlur={commitEdit}
-                            onCancel={() => {
-                              setEditingCell(null);
-                              setEditValue("");
-                            }}
-                            onCommit={(val) => {
-                              onUpdate(tx.id, { source: val.trim() || null });
-                              setEditingCell(null);
-                              setEditValue("");
-                            }}
-                            suggestions={allSources}
-                            positionerZIndex={50}
+                            onKeyDown={handleKeyDown}
+                            className={editInputClass}
                           />
                         ) : (
                           <span className="block py-px">
@@ -1463,23 +1452,15 @@ const TransactionTable = ({
                             }
                           >
                             {isEditing(child.id, "category") ? (
-                              <InputAutocomplete
+                              <input
+                                ref={inputRef as React.RefObject<HTMLInputElement>}
+                                type="text"
                                 value={editValue}
-                                onChange={setEditValue}
+                                autoCapitalize="none"
+                                onChange={(e) => setEditValue(e.target.value)}
                                 onBlur={commitEdit}
-                                onCancel={() => {
-                                  setEditingCell(null);
-                                  setEditValue("");
-                                }}
-                                onCommit={(val) => {
-                                  onUpdate(child.id, {
-                                    category: val.trim() || null,
-                                  });
-                                  setEditingCell(null);
-                                  setEditValue("");
-                                }}
-                                suggestions={allCategories}
-                                positionerZIndex={50}
+                                onKeyDown={handleKeyDown}
+                                className={editInputClass}
                               />
                             ) : (
                               <span className="cursor-text block py-px">
@@ -1576,23 +1557,15 @@ const TransactionTable = ({
                             }
                           >
                             {isEditing(child.id, "source") ? (
-                              <InputAutocomplete
+                              <input
+                                ref={inputRef as React.RefObject<HTMLInputElement>}
+                                type="text"
                                 value={editValue}
-                                onChange={setEditValue}
+                                autoCapitalize="none"
+                                onChange={(e) => setEditValue(e.target.value)}
                                 onBlur={commitEdit}
-                                onCancel={() => {
-                                  setEditingCell(null);
-                                  setEditValue("");
-                                }}
-                                onCommit={(val) => {
-                                  onUpdate(child.id, {
-                                    source: val.trim() || null,
-                                  });
-                                  setEditingCell(null);
-                                  setEditValue("");
-                                }}
-                                suggestions={allSources}
-                                positionerZIndex={50}
+                                onKeyDown={handleKeyDown}
+                                className={editInputClass}
                               />
                             ) : (
                               <span className="cursor-text block py-px">


### PR DESCRIPTION
## Summary

- Replace `InputAutocomplete` with plain `<input>` for category and source columns in the transaction table — both the inline edit cells and the add-row fields
- Inputs now match the description column's look and behavior: same styling, text is not auto-capitalized, and clicking to edit highlights the full existing value
- Fix stale-value flicker on transaction update by applying all optimistic state updates before `await`ing the API call instead of after

## Changes

- **`components/TransactionTable.tsx`** — removed `InputAutocomplete` import; replaced all 6 usages (parent row, child row, add row × category and source) with `<input type="text">` using `editInputClass`/`addInputClass`, `autoCapitalize="none"`, and standard `onBlur`/`onKeyDown` handlers
- **`app/page.tsx`** — in `handleUpdateTransaction`, moved all `setPageRows`, `setChildRows`, `setAllGroups`, `setPinnedRow`, and `setTotalAmount` calls above the `await fetch(...)` so the UI reflects the new value instantly; moved `parentGroupId` lookup to the top before `childRows` is mutated
