### PR TITLE
50-update-add-transaction

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -143,7 +143,6 @@ const Home = () => {
     setAllSources(data.sources);
   }, [session?.user?.id]);
 
-
   // Debounce text/range filters — reset to page 1 and clear pinned row
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -433,7 +432,10 @@ const Home = () => {
         ...addedTransactions.map((tx) => ({ ...tx, parentId: groupId })),
       ];
       setChildRows((prev) => ({ ...prev, [groupId]: updatedChildren }));
-      handleUpdateTransaction(groupId, computeGroupFields(updatedChildren));
+      await handleUpdateTransaction(
+        groupId,
+        computeGroupFields(updatedChildren),
+      );
     }
 
     fetchPage({
@@ -455,29 +457,32 @@ const Home = () => {
       body: JSON.stringify({ parentId: null }),
     });
 
-    setChildRows((prev) => {
-      const next = { ...prev };
-      for (const groupId of Object.keys(next)) {
-        next[groupId] = next[groupId].filter((tx) => tx.id !== childId);
-      }
-      return next;
-    });
-
     if (parentGroupId) {
       const remaining = childRows[parentGroupId].filter(
         (tx) => tx.id !== childId,
       );
       if (remaining.length === 0) {
-        handleDeleteTransaction(parentGroupId);
+        await handleDeleteTransaction(parentGroupId);
         return;
       }
-      handleUpdateTransaction(parentGroupId, computeGroupFields(remaining));
+      await handleUpdateTransaction(
+        parentGroupId,
+        computeGroupFields(remaining),
+      );
     }
 
     fetchPage({
       page: currentPage,
       sortBy: sortConfig?.key ?? null,
       sortDir: sortConfig?.direction ?? null,
+    });
+
+    setChildRows((prev) => {
+      const next = { ...prev };
+      for (const groupId of Object.keys(next)) {
+        next[groupId] = next[groupId].filter((tx) => tx.id !== childId);
+      }
+      return next;
     });
   };
 

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -211,6 +211,8 @@ const TransactionTable = ({
   const [newTransaction, setNewTransaction] = useState<Partial<Transaction>>(emptyNewTransaction);
   const [showAddErrors, setShowAddErrors] = useState(false);
 
+  const newDescriptionRef = useRef<HTMLInputElement>(null);
+
   const attachingTxIdRef = useRef<{
     id: string;
     date: string;
@@ -576,7 +578,7 @@ const TransactionTable = ({
     const tx = allTransactions.find((t) => t.id === id);
     if (field === "amount") {
       const parsed = parseFloat(editValue);
-      if (!isNaN(parsed) && parsed !== tx?.amount)
+      if (!isNaN(parsed) && parsed !== Number(tx?.amount))
         onUpdate(id, { amount: parsed });
     } else if (field === "date") {
       if (editValue && editValue !== tx?.date)
@@ -607,6 +609,17 @@ const TransactionTable = ({
     }
   };
 
+  const handleNewRowKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSaveNew();
+    } else if (e.key === "Escape") {
+      setShowAddErrors(false);
+      setNewTransaction(emptyNewTransaction);
+      onCancelAdd();
+    }
+  };
+
   const handleSaveNew = async () => {
     if (
       !newTransaction.date ||
@@ -630,6 +643,7 @@ const TransactionTable = ({
     });
     setShowAddErrors(false);
     setNewTransaction(emptyNewTransaction);
+    newDescriptionRef.current?.focus();
   };
 
   const formatDate = (dateString: string) => {
@@ -930,7 +944,7 @@ const TransactionTable = ({
             )}
             {/* Add Transaction Row */}
             {showAddRow && (
-              <tr className="bg-gray-50/50 dark:bg-[#1b1b1b]/50 border-b border-gray-200 dark:border-gray-700">
+              <tr className="border-b border-gray-100 dark:border-gray-800" onKeyDown={handleNewRowKeyDown}>
                 <td className="h-9 px-3" />
                 {/* Date */}
                 <td className="h-9 px-3">
@@ -950,6 +964,7 @@ const TransactionTable = ({
                 {/* Description */}
                 <td className="h-9 px-3">
                   <input
+                    ref={newDescriptionRef}
                     type="text"
                     placeholder="Description..."
                     value={newTransaction.description}
@@ -1330,7 +1345,7 @@ const TransactionTable = ({
                       </td>
 
                       {/* Controls */}
-                      <td className={`${tdClass} text-right`}>
+                      <td className={tdClass}>
                         <button
                           aria-label={
                             tx.isGroup
@@ -1598,7 +1613,7 @@ const TransactionTable = ({
                           </td>
 
                           {/* Unlink from group */}
-                          <td className={`${tdClass} text-right`}>
+                          <td className={`${tdClass}`}>
                             <button
                               aria-label="Remove from group"
                               title="Remove from group"


### PR DESCRIPTION
## Summary

Keyboard shortcuts, UX polish, and bug fixes for the add-transaction row and group update flow.

## Changes

- **Add-row keyboard shortcuts** — `Enter` saves the transaction (same as the checkmark button); `Escape` hides the row and resets the form
- **Focus after save** — focus returns to the description input after a new transaction is created so the next entry can be typed immediately
- **Add-row styling** — removed the distinct background and border so the new-transaction row matches regular rows

## Bug Fixes

- **Spurious PUT on amount click** — Drizzle returns `decimal` columns as strings; strict `!==` against a parsed number always evaluated to `true`, firing a PUT on every blur even with no change. Fixed by normalizing with `Number()` before comparing.
- **Group fields reverting after add-to-group / unlink** — `handleUpdateTransaction` was not awaited before `fetchPage` ran, causing the refetch to race against the group PUT and overwrite optimistic state with stale DB data. Fixed by awaiting the group update in both `handleAddToGroup` and `handleUnlinkChild`.
