### PR TITLE
Styling fixes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import {
 import TransactionTable from "@/components/TransactionTable";
 import CSVImportModal from "@/components/CSVImportModal";
 import Pagination from "@/components/Pagination";
-import { Plus, Upload } from "lucide-react";
+import { Plus, Upload, X } from "lucide-react";
 import { computeGroupFields } from "@/lib/groupUtils";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
@@ -579,18 +579,18 @@ const Home = () => {
           <div className="flex items-center">
             <button
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-gray-900 hover:bg-gray-50 dark:text-foreground dark:hover:bg-[#424242] rounded transition-colors"
+              onClick={() => setShowAddRow(!showAddRow)}
+            >
+              {showAddRow ? <X className="w-4 h-4" /> : <Plus className="w-4 h-4" />}
+              New
+            </button>
+            
+            <button
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-gray-900 hover:bg-gray-50 dark:text-foreground dark:hover:bg-[#424242] rounded transition-colors"
               onClick={() => setIsImportModalOpen(true)}
             >
               <Upload className="w-4 h-4" />
               Import
-            </button>
-
-            <button
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-gray-900 hover:bg-gray-50 dark:text-foreground dark:hover:bg-[#424242] rounded transition-colors"
-              onClick={() => setShowAddRow(true)}
-            >
-              <Plus className="w-4 h-4" />
-              New
             </button>
 
             <SettingsDrawer

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,6 +58,12 @@ const Home = () => {
   const [allGroups, setAllGroups] = useState<Transaction[]>([]);
   const [allCategories, setAllCategories] = useState<string[]>([]);
   const [allSources, setAllSources] = useState<string[]>([]);
+  const [groupFilters, setGroupFilters] = useState<Record<string, string[]>>({});
+  const [showGroupFilters, setShowGroupFilters] = useState(() => {
+    if (typeof window === "undefined") return true;
+    const stored = localStorage.getItem("showGroupFilters");
+    return stored === null ? true : stored === "true";
+  });
   const [pinnedRow, setPinnedRow] = useState<Transaction | null>(null);
   const [columnFilters, setColumnFilters] = useState<ColumnFilters>({
     category: [],
@@ -413,10 +419,26 @@ const Home = () => {
   };
 
   const handleAddToGroup = async (groupId: string) => {
-    if (selectedUngrouped.length === 0) return;
+    const selectedTxs = [...selectedMap.values()].filter(
+      (tx) => !tx.isGroup && tx.id !== groupId,
+    );
+    if (selectedTxs.length === 0) return;
 
-    const addedTransactions = selectedUngrouped;
-    const childIds = addedTransactions.map((tx) => tx.id);
+    const childIds = selectedTxs.map((tx) => tx.id);
+
+    // Snapshot old-group remaining arrays before any state mutation
+    const oldGroupIds = [...new Set(
+      selectedTxs.map((tx) => tx.parentId).filter(Boolean) as string[],
+    )].filter((id) => id !== groupId);
+
+    const oldGroupRemainders = new Map(
+      oldGroupIds
+        .filter((id) => childRows[id])
+        .map((id) => [
+          id,
+          childRows[id].filter((tx) => !childIds.includes(tx.id)),
+        ]),
+    );
 
     await fetch("/api/transactions", {
       method: "PUT",
@@ -426,16 +448,66 @@ const Home = () => {
 
     clearSelected();
 
+    // Update childRows: remove from old groups, add to new group
+    setChildRows((prev) => {
+      const next = { ...prev };
+      for (const oldId of oldGroupIds) {
+        if (next[oldId]) {
+          next[oldId] = next[oldId].filter((tx) => !childIds.includes(tx.id));
+        }
+      }
+      if (next[groupId]) {
+        const existing = next[groupId].filter((tx) => !childIds.includes(tx.id));
+        next[groupId] = [
+          ...existing,
+          ...selectedTxs.map((tx) => ({ ...tx, parentId: groupId })),
+        ];
+      }
+      return next;
+    });
+
+    // Recompute or delete old groups
+    for (const [oldId, remaining] of oldGroupRemainders) {
+      if (remaining.length === 0) {
+        await fetch(`/api/transactions/${oldId}`, { method: "DELETE" });
+        setExpandedIds((prev) => { const s = new Set(prev); s.delete(oldId); return s; });
+        setChildRows((prev) => { const next = { ...prev }; delete next[oldId]; return next; });
+        setPageRows((prev) => prev.filter((tx) => tx.id !== oldId));
+        setAllGroups((prev) => prev.filter((g) => g.id !== oldId));
+      } else {
+        const groupUpdates = computeGroupFields(remaining);
+        setPageRows((prev) =>
+          prev.map((tx) => (tx.id === oldId ? { ...tx, ...groupUpdates } : tx)),
+        );
+        setAllGroups((prev) =>
+          prev.map((g) => (g.id === oldId ? { ...g, ...groupUpdates } : g)),
+        );
+        await fetch(`/api/transactions/${oldId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(groupUpdates),
+        });
+      }
+    }
+
+    // Recompute new group summary
     if (childRows[groupId]) {
       const updatedChildren = [
-        ...childRows[groupId],
-        ...addedTransactions.map((tx) => ({ ...tx, parentId: groupId })),
+        ...childRows[groupId].filter((tx) => !childIds.includes(tx.id)),
+        ...selectedTxs.map((tx) => ({ ...tx, parentId: groupId })),
       ];
-      setChildRows((prev) => ({ ...prev, [groupId]: updatedChildren }));
-      await handleUpdateTransaction(
-        groupId,
-        computeGroupFields(updatedChildren),
+      const groupUpdates = computeGroupFields(updatedChildren);
+      setPageRows((prev) =>
+        prev.map((tx) => (tx.id === groupId ? { ...tx, ...groupUpdates } : tx)),
       );
+      setAllGroups((prev) =>
+        prev.map((g) => (g.id === groupId ? { ...g, ...groupUpdates } : g)),
+      );
+      await fetch(`/api/transactions/${groupId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(groupUpdates),
+      });
     }
 
     fetchPage({
@@ -487,12 +559,60 @@ const Home = () => {
   };
 
   const handleBulkDelete = async (ids: string[]) => {
+    const idSet = new Set(ids);
+
+    // Snapshot affected parent groups before mutation
+    const affectedGroups = new Map(
+      Object.entries(childRows)
+        .filter(([, children]) => children.some((c) => idSet.has(c.id)))
+        .map(([groupId, children]) => [
+          groupId,
+          children.filter((c) => !idSet.has(c.id)),
+        ]),
+    );
+
     await fetch("/api/transactions", {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ids }),
     });
+
     clearSelected();
+
+    // Remove deleted children from childRows
+    setChildRows((prev) => {
+      const next = { ...prev };
+      for (const groupId of Object.keys(next)) {
+        next[groupId] = next[groupId].filter((tx) => !idSet.has(tx.id));
+      }
+      return next;
+    });
+
+    // Recompute or delete parent groups whose children were deleted
+    for (const [groupId, remaining] of affectedGroups) {
+      if (idSet.has(groupId)) continue; // group itself was also deleted
+      if (remaining.length === 0) {
+        await fetch(`/api/transactions/${groupId}`, { method: "DELETE" });
+        setExpandedIds((prev) => { const s = new Set(prev); s.delete(groupId); return s; });
+        setChildRows((prev) => { const next = { ...prev }; delete next[groupId]; return next; });
+        setPageRows((prev) => prev.filter((tx) => tx.id !== groupId));
+        setAllGroups((prev) => prev.filter((g) => g.id !== groupId));
+      } else {
+        const groupUpdates = computeGroupFields(remaining);
+        setPageRows((prev) =>
+          prev.map((tx) => (tx.id === groupId ? { ...tx, ...groupUpdates } : tx)),
+        );
+        setAllGroups((prev) =>
+          prev.map((g) => (g.id === groupId ? { ...g, ...groupUpdates } : g)),
+        );
+        await fetch(`/api/transactions/${groupId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(groupUpdates),
+        });
+      }
+    }
+
     fetchPage({
       page: currentPage,
       sortBy: sortConfig?.key ?? null,
@@ -504,9 +624,21 @@ const Home = () => {
     ids: string[],
     updates: Partial<Transaction>,
   ) => {
+    const idSet = new Set(ids);
     setPageRows((prev) =>
-      prev.map((tx) => (ids.includes(tx.id) ? { ...tx, ...updates } : tx)),
+      prev.map((tx) => (idSet.has(tx.id) ? { ...tx, ...updates } : tx)),
     );
+    setChildRows((prev) => {
+      const next = { ...prev };
+      for (const groupId of Object.keys(next)) {
+        if (next[groupId].some((tx) => idSet.has(tx.id))) {
+          next[groupId] = next[groupId].map((tx) =>
+            idSet.has(tx.id) ? { ...tx, ...updates } : tx,
+          );
+        }
+      }
+      return next;
+    });
     await fetch("/api/transactions", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -554,7 +686,7 @@ const Home = () => {
     <main className="h-screen flex flex-col overflow-hidden text-gray-900 dark:text-foreground font-sans">
       <div className="max-w-5xl w-full mx-auto px-6 py-12 flex flex-col flex-1 min-h-0">
         {/* Header Area */}
-        <header className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8 shrink-0">
+        <header className="flex justify-between items-center gap-4 mb-8 shrink-0">
           {/* Main Logo */}
           <div className="flex items-center gap-2">
             <img
@@ -599,13 +731,18 @@ const Home = () => {
                 localStorage.setItem("showTotalsRow", String(val));
                 setShowTotalsRow(val);
               }}
+              showGroupFilters={showGroupFilters}
+              onToggleGroupFilters={(val) => {
+                localStorage.setItem("showGroupFilters", String(val));
+                setShowGroupFilters(val);
+              }}
             />
           </div>
         </header>
 
         {/* Main Table */}
         <div
-          className={`mt-4 flex-1 min-h-0 flex flex-col transition-opacity ${isLoading ? "opacity-60 pointer-events-none" : ""}`}
+          className={`mt-2 flex-1 min-h-0 flex flex-col transition-opacity ${isLoading ? "opacity-60 pointer-events-none" : ""}`}
         >
           <TransactionTable
             transactions={displayRows}
@@ -651,6 +788,11 @@ const Home = () => {
             totalAmount={totalAmount}
             showTotalsRow={showTotalsRow}
             scrollToTopRef={scrollToTopRef}
+            groupFilters={groupFilters}
+            onGroupFilterChange={(groupId, categories) =>
+              setGroupFilters((prev) => ({ ...prev, [groupId]: categories }))
+            }
+            showGroupFilters={showGroupFilters}
           />
         </div>
         <div className="shrink-0">

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -11,9 +11,11 @@ type Theme = "light" | "dark" | "system";
 interface SettingsDrawerProps {
   showTotalsRow: boolean;
   onToggleTotalsRow: (val: boolean) => void;
+  showGroupFilters: boolean;
+  onToggleGroupFilters: (val: boolean) => void;
 }
 
-export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: SettingsDrawerProps) {
+export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow, showGroupFilters, onToggleGroupFilters }: SettingsDrawerProps) {
   const { data: session } = authClient.useSession();
   const router = useRouter();
   const [theme, setTheme] = useState<Theme>(() => {
@@ -167,6 +169,21 @@ export default function SettingsDrawer({ showTotalsRow, onToggleTotalsRow }: Set
                     >
                       <span
                         className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white dark:bg-gray-900 shadow-sm transition-transform mt-0.5 ${showTotalsRow ? "translate-x-4.5" : "translate-x-0.5"}`}
+                      />
+                    </button>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <span className="text-[13px] font-medium text-gray-600 dark:text-gray-400">
+                      Show Group Filters
+                    </span>
+                    <button
+                      role="switch"
+                      aria-checked={showGroupFilters}
+                      onClick={() => onToggleGroupFilters(!showGroupFilters)}
+                      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors ${showGroupFilters ? "bg-gray-900 dark:bg-gray-100" : "bg-gray-200 dark:bg-gray-700"}`}
+                    >
+                      <span
+                        className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white dark:bg-gray-900 shadow-sm transition-transform mt-0.5 ${showGroupFilters ? "translate-x-4.5" : "translate-x-0.5"}`}
                       />
                     </button>
                   </div>

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -133,6 +133,9 @@ interface TransactionTableProps {
   totalAmount: number;
   showTotalsRow: boolean;
   scrollToTopRef?: React.RefObject<(() => void) | null>;
+  groupFilters: Record<string, string[]>;
+  onGroupFilterChange: (groupId: string, categories: string[]) => void;
+  showGroupFilters: boolean;
 }
 
 const localToday = () => {
@@ -196,6 +199,9 @@ const TransactionTable = ({
   totalAmount,
   showTotalsRow,
   scrollToTopRef,
+  groupFilters,
+  onGroupFilterChange,
+  showGroupFilters,
 }: TransactionTableProps) => {
   const emptyNewTransaction: Partial<Transaction> = {
     date: localToday(),
@@ -220,6 +226,9 @@ const TransactionTable = ({
   }, [showAddRow]);
 
   const newDescriptionRef = useRef<HTMLInputElement>(null);
+  const [groupDescSearch, setGroupDescSearch] = useState<Record<string, string>>({});
+  const lastClickedIdRef = useRef<string | null>(null);
+  const shiftKeyRef = useRef(false);
 
   const attachingTxIdRef = useRef<{
     id: string;
@@ -1083,6 +1092,22 @@ const TransactionTable = ({
                   : [];
                 const isSelected = selectedIds.has(tx.id) && !tx.isGroup;
 
+                // Group filter state — computed here so parent row can use it
+                const activeFilters = tx.isGroup && isExpanded && showGroupFilters ? (groupFilters[tx.id] ?? []) : [];
+                const descSearch = tx.isGroup && isExpanded && showGroupFilters ? (groupDescSearch[tx.id] ?? "") : "";
+                const uniqueCategories = tx.isGroup && isExpanded
+                  ? [...new Set(children.map((c) => c.category ?? ""))].sort()
+                  : [];
+                const filteredChildren = tx.isGroup && isExpanded
+                  ? children.filter((c) => {
+                      const matchesCategory = activeFilters.length === 0 || activeFilters.includes(c.category ?? "");
+                      const matchesDesc = !descSearch || c.description.toLowerCase().includes(descSearch.toLowerCase());
+                      return matchesCategory && matchesDesc;
+                    })
+                  : children;
+                const filteredTotal = filteredChildren.reduce((sum, c) => sum + Number(c.amount), 0);
+                const isFiltered = activeFilters.length > 0 || !!descSearch;
+
                 return (
                   <React.Fragment key={tx.id}>
                     {/* Parent / regular row */}
@@ -1110,11 +1135,27 @@ const TransactionTable = ({
                             )}
                           </button>
                         ) : (
-                          <label className="flex items-center justify-center w-full h-full min-h-8 cursor-pointer">
+                          <label
+                            className="flex items-center justify-center w-full h-full min-h-8 cursor-pointer select-none"
+                            onMouseDown={(e) => { shiftKeyRef.current = e.shiftKey; }}
+                          >
                             <input
                               type="checkbox"
                               checked={isSelected}
-                              onChange={() => onToggleSelect(tx)}
+                              onChange={() => {
+                                if (shiftKeyRef.current && lastClickedIdRef.current !== null) {
+                                  const lastIdx = transactions.findIndex(t => t.id === lastClickedIdRef.current);
+                                  const currIdx = transactions.findIndex(t => t.id === tx.id);
+                                  if (lastIdx !== -1) {
+                                    const from = Math.min(lastIdx, currIdx);
+                                    const to = Math.max(lastIdx, currIdx);
+                                    onSelectAll(transactions.slice(from, to + 1));
+                                    return;
+                                  }
+                                }
+                                onToggleSelect(tx);
+                                lastClickedIdRef.current = tx.id;
+                              }}
                               className="w-3.5 h-3.5 accent-gray-900 dark:accent-gray-300 cursor-pointer"
                             />
                           </label>
@@ -1182,7 +1223,10 @@ const TransactionTable = ({
                             </span>
                             {tx.isGroup && tx.childCount !== undefined && (
                               <span className="text-gray-400 dark:text-gray-500 text-[11px] font-normal">
-                                · {tx.childCount}{" "}
+                                ·{" "}
+                                {isFiltered && isExpanded
+                                  ? `${filteredChildren.length} of ${tx.childCount}`
+                                  : tx.childCount}{" "}
                                 {tx.childCount === 1
                                   ? "Transaction"
                                   : "Transactions"}
@@ -1249,7 +1293,9 @@ const TransactionTable = ({
                           />
                         ) : (
                           <span className="block py-px">
-                            {formatAmount(tx.amount)}
+                            {tx.isGroup && isExpanded && isFiltered
+                              ? formatAmount(filteredTotal)
+                              : formatAmount(tx.amount)}
                           </span>
                         )}
                       </td>
@@ -1363,14 +1409,99 @@ const TransactionTable = ({
                     </tr>
 
                     {/* Child rows */}
-                    {tx.isGroup &&
-                      isExpanded &&
-                      children.map((child) => (
+                    {tx.isGroup && isExpanded && (() => {
+                      return (
+                        <>
+                          {/* Filter bar */}
+                          {showGroupFilters && (
+                            <tr className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-[#1a1a1a]">
+                              {/* chevron col — x clear */}
+                              <td className="py-1.5 w-8 align-middle text-center">
+                                {isFiltered && (
+                                  <button
+                                    onClick={() => {
+                                      onGroupFilterChange(tx.id, []);
+                                      setGroupDescSearch((prev) => ({ ...prev, [tx.id]: "" }));
+                                    }}
+                                    className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors"
+                                    aria-label="Clear filters"
+                                  >
+                                    <X className="w-3 h-3" />
+                                  </button>
+                                )}
+                              </td>
+                              {/* date col — empty */}
+                              <td className="py-1.5" />
+                              {/* description col */}
+                              <td className="px-4 py-1.5">
+                                <input
+                                  type="text"
+                                  placeholder="Search..."
+                                  value={groupDescSearch[tx.id] ?? ""}
+                                  onChange={(e) =>
+                                    setGroupDescSearch((prev) => ({ ...prev, [tx.id]: e.target.value }))
+                                  }
+                                  className="h-6 w-full bg-transparent text-[12px] text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500 border border-gray-200 dark:border-gray-700 focus:border-gray-400 dark:focus:border-gray-500 rounded px-1.5 outline-none transition-colors"
+                                />
+                              </td>
+                              {/* category col */}
+                              <td className="px-4 py-1.5">
+                                <select
+                                  value={activeFilters.length === 0 ? "__all__" : activeFilters[0]}
+                                  onChange={(e) =>
+                                    onGroupFilterChange(tx.id, e.target.value !== "__all__" ? [e.target.value] : [])
+                                  }
+                                  className="h-6 w-full rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-[#2a2a2a] text-[12px] text-gray-700 dark:text-gray-300 px-1.5 outline-none focus:border-gray-400 dark:focus:border-gray-500 transition-colors cursor-pointer"
+                                >
+                                  <option value="__all__">All</option>
+                                  {uniqueCategories.map((cat) => (
+                                    <option key={cat} value={cat}>
+                                      {cat === "" ? "None" : cat}
+                                    </option>
+                                  ))}
+                                </select>
+                              </td>
+                              {/* remaining cols */}
+                              <td colSpan={5} />
+                            </tr>
+                          )}
+
+                          {/* Filtered child rows */}
+                          {filteredChildren.map((child) => (
                         <tr
                           key={child.id}
-                          className="group hover:bg-gray-50/70 dark:hover:bg-[#424242] transition-colors"
+                          className={`group transition-colors ${
+                            selectedIds.has(child.id)
+                              ? "bg-blue-50/60 hover:bg-gray-50 dark:bg-[#282828] dark:hover:bg-[#424242]"
+                              : "hover:bg-gray-50/70 dark:hover:bg-[#424242]"
+                          }`}
                         >
-                          <td className={`${tdClass} w-8`} />
+                          <td className={`${tdClass} w-8 align-middle`}>
+                            <label
+                              className="flex items-center justify-center w-full h-full min-h-8 cursor-pointer select-none"
+                              onMouseDown={(e) => { shiftKeyRef.current = e.shiftKey; }}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={selectedIds.has(child.id)}
+                                onChange={() => {
+                                  if (shiftKeyRef.current && lastClickedIdRef.current !== null) {
+                                    const lastIdx = filteredChildren.findIndex(c => c.id === lastClickedIdRef.current);
+                                    const currIdx = filteredChildren.findIndex(c => c.id === child.id);
+                                    if (lastIdx !== -1) {
+                                      const from = Math.min(lastIdx, currIdx);
+                                      const to = Math.max(lastIdx, currIdx);
+                                      onSelectAll(filteredChildren.slice(from, to + 1));
+                                      return;
+                                    }
+                                  }
+                                  onToggleSelect(child);
+                                  lastClickedIdRef.current = child.id;
+                                }}
+                                className="w-3.5 h-3.5 accent-gray-900 dark:accent-gray-300 cursor-pointer"
+                              />
+                            </label>
+                          </td>
 
                           {/* Date indented */}
                           <td className={`${tdClass}`}>
@@ -1621,7 +1752,11 @@ const TransactionTable = ({
                             </button>
                           </td>
                         </tr>
-                      ))}
+                          ))}
+
+                        </>
+                      );
+                    })()}
                   </React.Fragment>
                 );
               })

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -211,6 +211,14 @@ const TransactionTable = ({
   const [newTransaction, setNewTransaction] = useState<Partial<Transaction>>(emptyNewTransaction);
   const [showAddErrors, setShowAddErrors] = useState(false);
 
+  useEffect(() => {
+    if (!showAddRow) {
+      setNewTransaction(emptyNewTransaction);
+      setShowAddErrors(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showAddRow]);
+
   const newDescriptionRef = useRef<HTMLInputElement>(null);
 
   const attachingTxIdRef = useRef<{
@@ -614,8 +622,6 @@ const TransactionTable = ({
       e.preventDefault();
       handleSaveNew();
     } else if (e.key === "Escape") {
-      setShowAddErrors(false);
-      setNewTransaction(emptyNewTransaction);
       onCancelAdd();
     }
   };
@@ -792,7 +798,7 @@ const TransactionTable = ({
                 </div>
                 {openFilterCol === "date" && renderDateRangeDropdown()}
               </th>
-              <th className={`${thClass} relative min-w-50 max-w-64`}>
+              <th className={`${thClass} relative min-w-64 max-w-80`}>
                 <div className="flex items-center justify-between gap-1">
                   <span
                     className="flex items-center cursor-pointer hover:text-gray-900 dark:hover:text-foreground transition-colors"
@@ -1047,23 +1053,14 @@ const TransactionTable = ({
                 {/* File — not available on new row */}
                 <td className="h-9 px-3" />
                 {/* Extra */}
-                <td className="py-1.5 px-3 text-right">
-                  <div className="flex items-center justify-end gap-2">
-                    <button
-                      onClick={handleSaveNew}
-                      aria-label="Save Transaction"
-                      className="p-1 text-gray-400 hover:text-emerald-600 dark:text-gray-500 dark:hover:text-emerald-400 transition-colors"
-                    >
-                      <Check className="w-4 h-4" />
-                    </button>
-                    <button
-                      onClick={() => { setShowAddErrors(false); setNewTransaction(emptyNewTransaction); onCancelAdd(); }}
-                      aria-label="Cancel"
-                      className="p-1 text-gray-400 hover:text-rose-600 dark:text-gray-500 dark:hover:text-rose-400 transition-colors"
-                    >
-                      <X className="w-4 h-4" />
-                    </button>
-                  </div>
+                <td className={tdClass}>
+                  <button
+                    onClick={handleSaveNew}
+                    aria-label="Save Transaction"
+                    className="p-1 text-gray-400 hover:text-emerald-600 dark:text-gray-500 dark:hover:text-emerald-400 transition-colors"
+                  >
+                    <Check className="w-4 h-4" />
+                  </button>
                 </td>
               </tr>
             )}
@@ -1157,7 +1154,7 @@ const TransactionTable = ({
 
                       {/* Description */}
                       <td
-                        className={`h-9 px-4 text-[13px] border-b border-gray-100 dark:border-gray-800 whitespace-nowrap text-gray-900 dark:text-foreground font-medium max-w-64`}
+                        className={`h-9 px-4 text-[13px] border-b border-gray-100 dark:border-gray-800 whitespace-nowrap text-gray-900 dark:text-foreground font-medium max-w-80`}
                         onClick={() =>
                           !isEditing(tx.id, "description") &&
                           startEditing(
@@ -1321,10 +1318,10 @@ const TransactionTable = ({
                       </td>
 
                       {/* File */}
-                      <td className={`${tdClass} flex items-center`}>
+                      <td className={`${tdClass} align-middle`}>
                         {!tx.isGroup &&
                           (uploadingIds.has(tx.id) ? (
-                            <FileText className="w-3.5 h-3.5 text-gray-500 dark:text-gray-400 animate-pulse" />
+                            <FileText className="w-4 h-4 text-gray-500 dark:text-gray-400 animate-pulse" />
                           ) : tx.driveFileId ? (
                             <DriveFileCell
                               fileId={tx.driveFileId}
@@ -1339,7 +1336,7 @@ const TransactionTable = ({
                               aria-label="Upload file to Drive"
                               title="Upload file to Google Drive"
                             >
-                              <Paperclip className="w-3.5 h-3.5" />
+                              <Paperclip className="w-4 h-4" />
                             </button>
                           ))}
                       </td>
@@ -1419,7 +1416,7 @@ const TransactionTable = ({
 
                           {/* Description */}
                           <td
-                            className={`${tdClass} dark:text-foreground max-w-64`}
+                            className={`${tdClass} dark:text-foreground max-w-80`}
                             onClick={() =>
                               !isEditing(child.id, "description") &&
                               startEditing(
@@ -1590,7 +1587,7 @@ const TransactionTable = ({
                           </td>
 
                           {/* File */}
-                          <td className={`${tdClass} flex items-center`}>
+                          <td className={`${tdClass} align-middle`}>
                             {uploadingIds.has(child.id) ? (
                               <FileText className="w-3.5 h-3.5 text-gray-500 dark:text-gray-400 animate-pulse" />
                             ) : child.driveFileId ? (


### PR DESCRIPTION
## Summary

UI and interaction improvements across the transaction table.

## Changes

### Group-level filtering
- Added a per-group filter bar that appears when a group is expanded
- Category dropdown and description search sit inline under their respective columns
- Filtered count ("3 of 7 Transactions") and filtered amount update live in the group's parent row
- X button in the chevron column clears both filters at once
- Fixed "None" category filter — transactions with no category now correctly match when selected

### Shift-select range selection
- Shift+click now selects a range of rows for both top-level and child (grouped) rows
- Child row range selection operates within the group's filtered children

### Settings
- Added **Group Filters** toggle under Appearance in the Settings drawer to show/hide the per-group filter bar

### Other fixes
- Add transaction row inputs now clear when the row is closed
- File column border alignment fixed
- Description column width increased
